### PR TITLE
Bump minimist, plotly.js and mkdirp

### DIFF
--- a/samples/csharp/end-to-end-apps/Forecasting-Sales/src/eShopDashboard/package-lock.json
+++ b/samples/csharp/end-to-end-apps/Forecasting-Sales/src/eShopDashboard/package-lock.json
@@ -5,26 +5,13 @@
   "requires": true,
   "dependencies": {
     "3d-view": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.0.tgz",
-      "integrity": "sha1-gxrpQtdQjFCAHj4G+v4ejFdOF74=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/3d-view/-/3d-view-2.0.1.tgz",
+      "integrity": "sha512-YSLRHXNpSziaaiK2R0pI5+JKguoJVbtWmIv9YyBFtl0+q42kQwJB/JUulbFR/1zYFm58ifjKQ6kVdgZ6tyKtCA==",
       "requires": {
         "matrix-camera-controller": "^2.1.1",
         "orbit-camera-controller": "^4.0.0",
         "turntable-camera-controller": "^3.0.0"
-      }
-    },
-    "3d-view-controls": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/3d-view-controls/-/3d-view-controls-2.2.2.tgz",
-      "integrity": "sha512-WL0u3PN41lEx/4qvKqV6bJlweUYoW18FXMshW/qHb41AVdZxDReLoJNGYsI7x6jf9bYelEF62BJPQmO7yEnG2w==",
-      "requires": {
-        "3d-view": "^2.0.0",
-        "has-passive-events": "^1.0.0",
-        "mouse-change": "^1.1.1",
-        "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.0.2",
-        "right-now": "^1.0.0"
       }
     },
     "@choojs/findup": {
@@ -35,43 +22,44 @@
         "commander": "^2.15.1"
       }
     },
-    "@mapbox/geojson-area": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
-      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
+    "@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "requires": {
-        "wgs84": "0.0.0"
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
       }
     },
-    "@mapbox/gl-matrix": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@mapbox/gl-matrix/-/gl-matrix-0.0.1.tgz",
-      "integrity": "sha1-5RJqq01kw2uBx6l9CuDd3eV3PSs="
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ=="
     },
     "@mapbox/mapbox-gl-supported": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz",
-      "integrity": "sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
-      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
-    },
-    "@mapbox/shelf-pack": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/shelf-pack/-/shelf-pack-3.2.0.tgz",
-      "integrity": "sha512-dyQxe6ukILV6qaEvxoKCIwhblgRjYp1ZGlClo4xvfbmxzFO5LYu7Tnrg2AZrRgN7VsSragsGcNjzUe9kCdKHYQ=="
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "@mapbox/tiny-sdf": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz",
-      "integrity": "sha512-dnhyk8X2BkDRWImgHILYAGgo+kuciNYX30CUKj/Qd5eNjh54OWM/mdOS/PWsPeN+3abtN+QDGYM4G220ynVJKA=="
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
+      "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw=="
     },
     "@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
-      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA=="
     },
     "@mapbox/vector-tile": {
       "version": "1.3.1",
@@ -87,24 +75,87 @@
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
     },
     "@plotly/d3-sankey": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.5.1.tgz",
-      "integrity": "sha512-uMToNGexOSLG0hBm+uAzElfFW0Pt2utgJ//puL5nuerNnPnRTTe3Un7XFVcWqRhvXEViF00Xq/8wGoA8i8eZJA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
+      "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
       "requires": {
         "d3-array": "1",
         "d3-collection": "1",
-        "d3-interpolate": "1"
+        "d3-shape": "^1.2.0"
       }
     },
-    "JSV": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
-      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
+    "@plotly/d3-sankey-circular": {
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
+      "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
+      "requires": {
+        "d3-array": "^1.2.1",
+        "d3-collection": "^1.0.4",
+        "d3-shape": "^1.2.0",
+        "elementary-circuits-directed-graph": "^1.0.4"
+      }
+    },
+    "@plotly/point-cluster": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
+      "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
+      "requires": {
+        "array-bounds": "^1.0.1",
+        "binary-search-bounds": "^2.0.4",
+        "clamp": "^1.0.1",
+        "defined": "^1.0.0",
+        "dtype": "^2.0.0",
+        "flatten-vertex-data": "^1.0.2",
+        "is-obj": "^1.0.1",
+        "math-log2": "^1.0.1",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0"
+      }
+    },
+    "@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/centroid": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.5.0.tgz",
+      "integrity": "sha512-MwE1oq5E3isewPprEClbfU5pXljIK/GUOMbn22UM3IFPDJX0KeoyLNwghszkdmFp/qMGL/M13MMWvU+GNLXP/A==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
     },
     "a-big-triangle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/a-big-triangle/-/a-big-triangle-1.0.3.tgz",
-      "integrity": "sha1-7v0wsCqPUl6LH3K7a7GwwWdRx5Q=",
+      "integrity": "sha512-AboEtoSPueZisde3Vr+7VRSfUIWBSGZUOtW3bJrOZXgIyK7dNNDdpDmOKJjg5GmJLlRKUONWV8lMgTK8MBhQWw==",
       "requires": {
         "gl-buffer": "^2.1.1",
         "gl-vao": "^1.2.0",
@@ -114,47 +165,17 @@
     "abs-svg-path": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
-      "integrity": "sha1-32Acjo0roQ1KdtYl4japo5wnI78="
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA=="
     },
     "acorn": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "requires": {
-        "acorn": "^3.0.4"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        }
-      }
-    },
-    "acorn-object-spread": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-object-spread/-/acorn-object-spread-1.0.0.tgz",
-      "integrity": "sha1-SOrQ9KjrFplaF6Dbn/xqyq2kumg=",
-      "requires": {
-        "acorn": "^3.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        }
-      }
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "add-line-numbers": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
-      "integrity": "sha1-SNu96kfb0jTer+rGyTzqb3C0t+M=",
+      "integrity": "sha512-w+2a1malCvWwACQFBpZ5/uwmHGaGYT+aGIxA8ONF5vlhe6X/gD3eR8qVoLWa+5nnWAOq2LuPbrqDYqj1pn0WMg==",
       "requires": {
         "pad-left": "^1.0.2"
       }
@@ -162,7 +183,7 @@
     "affine-hull": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/affine-hull/-/affine-hull-1.0.0.tgz",
-      "integrity": "sha1-dj/x040GPOt+Jy8X7k17vK+QXF0=",
+      "integrity": "sha512-3QNG6+vFAwJvSZHsJYDJ/mt1Cxx9n5ffA+1Ohmj7udw0JuRgUVIXK0P9N9pCMuEdS3jCNt8GFX5q2fChq+GO3Q==",
       "requires": {
         "robust-orientation": "^1.1.3"
       }
@@ -171,6 +192,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -180,12 +202,12 @@
     "almost-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
-      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
+      "integrity": "sha512-0V/PkoculFl5+0Lp47JoxUcO0xSxhIBvm+BxHdD/OgXNmdRpRHCFnKVuUoWyS9EzQP+otSGv0m9Lb4yVkQBn2A=="
     },
     "alpha-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/alpha-complex/-/alpha-complex-1.0.0.tgz",
-      "integrity": "sha1-kIZYcNawVCrnPAwTHU75iWabctI=",
+      "integrity": "sha512-rhsjKfc9tMF5QZc0NhKz/zFzMu2rvHxCP/PyJtEmMkV7M848YjIoQGDlNGp+vTqxXjA8wAY2OxgR1K54C2Awkg==",
       "requires": {
         "circumradius": "^1.0.0",
         "delaunay-triangulate": "^1.1.6"
@@ -194,7 +216,7 @@
     "alpha-shape": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/alpha-shape/-/alpha-shape-1.0.0.tgz",
-      "integrity": "sha1-yDEJkj7P2mZ9IWP+Tyb+JHJvZKk=",
+      "integrity": "sha512-/V+fmmjtSA2yfQNq8iEqBxnPbjcOMXpM9Ny+yE/O7aLR7Q1oPzUc9bHH0fPHS3hUugUL/dHzTis6l3JirYOS/w==",
       "requires": {
         "alpha-complex": "^1.0.0",
         "simplicial-complex-boundary": "^1.0.0"
@@ -203,7 +225,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-gray": {
       "version": "0.1.1",
@@ -217,15 +240,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-wrap": {
       "version": "0.1.0",
@@ -233,31 +249,11 @@
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
-    "ansicolors": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
-      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
-    },
     "archy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      },
-      "dependencies": {
-        "sprintf-js": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-        }
-      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -297,13 +293,12 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
     },
     "array-normalize": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.3.tgz",
-      "integrity": "sha1-c/uDf0gW7BkVHTxejYU6RZDOAb0=",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
+      "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
       "requires": {
         "array-bounds": "^1.0.0"
       }
@@ -311,7 +306,7 @@
     "array-range": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
-      "integrity": "sha1-9W5GWRhDYRxqVvd+8C7afFAIm/w="
+      "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA=="
     },
     "array-rearrange": {
       "version": "2.2.2",
@@ -357,22 +352,18 @@
     "atob-lite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
-      "integrity": "sha1-uI3KYAaSK5YglPdVaCa6sxxKKWs="
-    },
-    "babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-ArXcmHR/vwSN37HLVap/Y5SKpz12CuEybxe1sIYl7th/S6SQPrVMNFt6rblJzCOAxn0SHbXpknUtqbAIeo3Aow=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "barycentric": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/barycentric/-/barycentric-1.0.1.tgz",
-      "integrity": "sha1-8VYruJGyb0/sRjqC7to2V4AOxog=",
+      "integrity": "sha512-47BuWXsenBbox4q1zqJrUoxq1oM1ysrYc5mdBACAwaP+CL+tcNauC3ybA0lzbIWzJCLZYMqebAx46EauTI2Nrg==",
       "requires": {
         "robust-linear-solve": "^1.0.0"
       }
@@ -447,7 +438,7 @@
     "big-rat": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/big-rat/-/big-rat-1.0.4.tgz",
-      "integrity": "sha1-do0JO7V5MN0Y7Vdcf8on3FORreo=",
+      "integrity": "sha512-AubEohDDrak6urvKkFMIlwPWyQbJ/eq04YsK/SNipH7NNiPCYchjQNvWYK5vyyMmtGXAmNmsAjIcfkaDuTtd8g==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "bn.js": "^4.11.6",
@@ -455,27 +446,24 @@
       }
     },
     "binary-search-bounds": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-1.0.0.tgz",
-      "integrity": "sha1-MjyjF+PypA9CRMclX1OEpbIHu2k="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
+      "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA=="
     },
     "bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
-      "integrity": "sha1-DGwfq+KyPRcXPZpht7cJPrnhdp4="
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA=="
     },
     "bitmap-sdf": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.3.tgz",
-      "integrity": "sha512-ojYySSvWTx21cbgntR942zgEgqj38wHctN64vr4vYRFf3GKVmI23YlA94meWGkFslidwLwGCsMy2laJ3g/94Sg==",
-      "requires": {
-        "clamp": "^1.0.1"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
+      "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg=="
     },
     "bl": {
-      "version": "1.2.2",
-      "resolved": "http://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+      "version": "2.2.1",
+      "resolved": "http://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "requires": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -484,12 +472,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.8",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -511,9 +499,9 @@
       }
     },
     "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "bootstrap": {
       "version": "4.3.1",
@@ -521,17 +509,14 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "boundary-cells": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.1.tgz",
-      "integrity": "sha1-6QWo0UGc9Hyza+Pb9SXbXiTeAEI=",
-      "requires": {
-        "tape": "^4.0.0"
-      }
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/boundary-cells/-/boundary-cells-2.0.2.tgz",
+      "integrity": "sha512-/S48oUFYEgZMNvdqC87iYRbLBAPHYijPRNrNpm/sS8u7ijIViKm/hrV3YD4sx/W68AsG5zLMyBEditVHApHU5w=="
     },
     "box-intersect": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.1.tgz",
-      "integrity": "sha1-tyilnj8aPHPCJJM8JmC5J6oTeQI=",
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/box-intersect/-/box-intersect-1.0.2.tgz",
+      "integrity": "sha512-yJeMwlmFPG1gIa7Rs/cGXeI6iOj6Qz5MG5PE61xLKpElUGzmJ4abm+qsLpzxKJFpsSDq742BQEocr8dI2t8Nxw==",
       "requires": {
         "bit-twiddle": "^1.0.2",
         "typedarray-pool": "^1.1.0"
@@ -541,6 +526,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -564,159 +550,10 @@
         "to-regex": "^3.0.1"
       }
     },
-    "brfs": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
-      "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
-      "requires": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "duplexer2": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-          "requires": {
-            "readable-stream": "^2.0.2"
-          }
-        },
-        "escodegen": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
-          "requires": {
-            "esprima": "^3.1.3",
-            "estraverse": "^4.2.0",
-            "esutils": "^2.0.2",
-            "optionator": "^0.8.1",
-            "source-map": "~0.6.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "magic-string": {
-          "version": "0.22.5",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
-          "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
-          "requires": {
-            "vlq": "^0.2.2"
-          }
-        },
-        "object-inspect": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
-          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
-        },
-        "quote-stream": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
-          "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
-          "requires": {
-            "buffer-equal": "0.0.1",
-            "minimist": "^1.1.3",
-            "through2": "^2.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "static-module": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
-          "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
-          "requires": {
-            "concat-stream": "~1.6.0",
-            "convert-source-map": "^1.5.1",
-            "duplexer2": "~0.1.4",
-            "escodegen": "~1.9.0",
-            "falafel": "^2.1.0",
-            "has": "^1.0.1",
-            "magic-string": "^0.22.4",
-            "merge-source-map": "1.0.4",
-            "object-inspect": "~1.4.0",
-            "quote-stream": "~1.0.2",
-            "readable-stream": "~2.3.3",
-            "shallow-copy": "~0.0.1",
-            "static-eval": "^2.0.0",
-            "through2": "~2.0.3"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        },
-        "vlq": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
-        }
-      }
-    },
-    "browserify-package-json": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-package-json/-/browserify-package-json-1.0.1.tgz",
-      "integrity": "sha1-mN3oqlxWH9bT/km7qhArdLOW/eo="
-    },
-    "buble": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/buble/-/buble-0.19.6.tgz",
-      "integrity": "sha512-9kViM6nJA1Q548Jrd06x0geh+BG2ru2+RMDkIHHgJY/8AcyCs34lTHwra9BX7YdPrZXd5aarkpr/SY8bmPgPdg==",
-      "requires": {
-        "chalk": "^2.4.1",
-        "magic-string": "^0.25.1",
-        "minimist": "^1.2.0",
-        "os-homedir": "^1.0.1",
-        "regexpu-core": "^4.2.0",
-        "vlq": "^1.0.0"
-      }
-    },
-    "bubleify": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-1.2.0.tgz",
-      "integrity": "sha512-SJnUsR+f8WeDw0K2l1S+VuYI33Cu5Gfghe5jTow/fpJueNtnwyoECyfCGsDuFoQt4QGhjpV3LYPpN0hxy90LgA==",
-      "requires": {
-        "buble": "^0.19.3"
-      }
-    },
-    "buffer-equal": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
-    },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -741,21 +578,11 @@
         "unset-value": "^1.0.0"
       }
     },
-    "call-matcher": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/call-matcher/-/call-matcher-1.1.0.tgz",
-      "integrity": "sha512-IoQLeNwwf9KTNbtSA7aEBb1yfDbdnzwjCetjkC8io5oGeOmK2CBNdg0xr+tadRYKO0p7uQyZzvon0kXlZbvGrw==",
-      "requires": {
-        "core-js": "^2.0.0",
-        "deep-equal": "^1.0.0",
-        "espurify": "^1.6.0",
-        "estraverse": "^4.0.0"
-      }
-    },
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
@@ -778,65 +605,40 @@
     "canvas-fit": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
-      "integrity": "sha1-rhO+Zq3kL1vg5IfjRfzjCl5bXl8=",
+      "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
       "requires": {
         "element-size": "^1.1.1"
-      }
-    },
-    "cardinal": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
-      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
-      "requires": {
-        "ansicolors": "~0.2.1",
-        "redeyed": "~0.4.0"
       }
     },
     "cdt2d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cdt2d/-/cdt2d-1.0.0.tgz",
-      "integrity": "sha1-TyEkNLzWe9s9aLj+9KzcLFRBUUE=",
+      "integrity": "sha512-pFKb7gVhpsI6onS5HUXRoqbBIJB4CJ+KPk8kgaIVcm0zFgOxIyBT5vzifZ4j1aoGVJS0U1A+S4oFDshuLAitlA==",
       "requires": {
         "binary-search-bounds": "^2.0.3",
         "robust-in-sphere": "^1.1.3",
         "robust-orientation": "^1.1.3"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
       }
     },
     "cell-orientation": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cell-orientation/-/cell-orientation-1.0.1.tgz",
-      "integrity": "sha1-tQStlqZq0obZ7dmFoiU9A7gNKFA="
+      "integrity": "sha512-DtEsrgP+donmPxpEZm7hK8zCPYDXAQ977ecJiE7G0gbTfnS6TZVBlief3IdRP/TZS1PVnJRGJTDdjSdV8mRDug=="
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
       }
     },
-    "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
     "circumcenter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/circumcenter/-/circumcenter-1.0.0.tgz",
-      "integrity": "sha1-INeqE7F/usUvUtpPVMasi5Bu5Sk=",
+      "integrity": "sha512-YRw0mvttcISviaOtSmaHb2G3ZVbkxzYPQeAEd57/CFFtmOkwfRTw9XuxYZ7PCi2BYa0NajjHV6bq4nbY1VCC8g==",
       "requires": {
         "dup": "^1.0.0",
         "robust-linear-solve": "^1.0.0"
@@ -845,7 +647,7 @@
     "circumradius": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/circumradius/-/circumradius-1.0.0.tgz",
-      "integrity": "sha1-cGxEfj5VzR7T0RvRM+N8JSzDBbU=",
+      "integrity": "sha512-5ltoQvWQzJiZjCVX9PBKgKt+nsuzOLKayqXMNllfRSqIp2L5jFpdanv1V6j27Ue7ACxlzmamlR+jnLy+NTTVTw==",
       "requires": {
         "circumcenter": "^1.0.0"
       }
@@ -853,7 +655,7 @@
     "clamp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
+      "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -911,7 +713,7 @@
     "clean-pslg": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/clean-pslg/-/clean-pslg-1.1.2.tgz",
-      "integrity": "sha1-vTXHRgt+irWp92Gl7VF5aqPIbBE=",
+      "integrity": "sha512-bJnEUR6gRiiNi2n4WSC6yrc0Hhn/oQDOTzs6evZfPwEF/VKVXM6xu0F4n/WSBz7TjTt/ZK6I5snRM9gVKMVAxA==",
       "requires": {
         "big-rat": "^1.0.3",
         "box-intersect": "^1.0.1",
@@ -926,6 +728,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
       "requires": {
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
@@ -935,7 +738,8 @@
         "wordwrap": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true
         }
       }
     },
@@ -1011,19 +815,11 @@
       }
     },
     "color-alpha": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.3.tgz",
-      "integrity": "sha512-ap5UCPpnpsSQu09ccl/5cNQDJlSFvkuXHMBY1+1vu6iKj6H9zw7Sz852snsETFsrYlPUnvTByCFAnYVynKJb9A==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
+      "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "requires": {
-        "color-parse": "^1.2.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "requires": {
-        "color-name": "1.1.3"
+        "color-parse": "^1.3.8"
       }
     },
     "color-id": {
@@ -1035,24 +831,24 @@
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "color-normalize": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.3.0.tgz",
-      "integrity": "sha512-BfOC/x9Q7bmrR1t/Mflfr9c4ZEbr3B+Sz3pWNG6xkcB8mFtF8z32MStJK0NSBmFVhHtFlfXQKOYC/ADbqmxHzg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
+      "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
       "requires": {
         "clamp": "^1.0.1",
-        "color-rgba": "^2.1.0",
+        "color-rgba": "^2.1.1",
         "dtype": "^2.0.0"
       }
     },
     "color-parse": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.7.tgz",
-      "integrity": "sha512-8G6rPfyTZhWYKU7D2hwywTjA4YlqX/Z7ClqTEzh5ENc5QkLOff0u8EuyNZR6xScEBhWpAyiDrrVGNUE/Btg2LA==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
+      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
       "requires": {
         "color-name": "^1.0.0",
         "defined": "^1.0.0",
@@ -1060,12 +856,12 @@
       }
     },
     "color-rgba": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.0.tgz",
-      "integrity": "sha512-yAmMouVOLRAtYJwP52qymiscIMpw2g7VO82pkW+a88BpW1AZ+O6JDxAAojLljGO0pQkkvZLLN9oQNTEgT+RFiw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.1.1.tgz",
+      "integrity": "sha512-VaX97wsqrMwLSOR6H7rU1Doa2zyVdmShabKrPEIFywLlHoibgD3QW9Dw6fSqM4+H/LfjprDNAUUW31qEQcGzNw==",
       "requires": {
         "clamp": "^1.0.1",
-        "color-parse": "^1.3.7",
+        "color-parse": "^1.3.8",
         "color-space": "^1.14.6"
       }
     },
@@ -1085,22 +881,22 @@
       "dev": true
     },
     "colormap": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.0.tgz",
-      "integrity": "sha512-Mkk6mQUMbCleXEeStFm2xLwv5zbRakZMUFB1T1+iNEv58VKBByfPwYIjMQDwSRmXNM1gvo5y3WTYAhmdMn/rbg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.2.tgz",
+      "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
       "requires": {
         "lerp": "^1.0.3"
       }
     },
     "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "compare-angle": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/compare-angle/-/compare-angle-1.0.1.tgz",
-      "integrity": "sha1-pOtjQW6jx0f8a9bItjZotN5PoSk=",
+      "integrity": "sha512-adM1/bpLFQFquh0/Qr5aiOPuztoga/lCf2Z45s+Oydgzf18F3wBSkdHmcHMeig0bD+dDKlz52u1rLOAOqiyE5A==",
       "requires": {
         "robust-orientation": "^1.0.2",
         "robust-product": "^1.0.0",
@@ -1112,12 +908,12 @@
     "compare-cell": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/compare-cell/-/compare-cell-1.0.0.tgz",
-      "integrity": "sha1-qetwj24OQa73qlZrEw8ZaNyeGqo="
+      "integrity": "sha512-uNIkjiNLZLhdCgouF39J+W04R7oP1vwrNME4vP2b2/bAa6PHOj+h8yXu52uPjPTKs5RatvqNsDVwEN7Yp19vNA=="
     },
     "compare-oriented-cell": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/compare-oriented-cell/-/compare-oriented-cell-1.0.1.tgz",
-      "integrity": "sha1-ahSf7vnfxPj8YjWOUd1C7/u9w54=",
+      "integrity": "sha512-9D7R2MQfsGGRskZAZF0TkJHt9eFNbFkZyVdVps+WUYxtRHgG77BLbieKgSkj7iEAb9PNDSU9QNa9MtigjQ3ktQ==",
       "requires": {
         "cell-orientation": "^1.0.1",
         "compare-cell": "^1.0.0"
@@ -1132,7 +928,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -1148,12 +945,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.8",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1183,18 +980,10 @@
         "source-map": "^0.6.1"
       }
     },
-    "convert-source-map": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
-    },
     "convex-hull": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/convex-hull/-/convex-hull-1.0.3.tgz",
-      "integrity": "sha1-IKOqbOh/St6i/30XlxyfwcZ+H/8=",
+      "integrity": "sha512-24rZAoh81t41GHPLAxcsokgjH9XNoVqU2OiSi8iMHUn6HUURfiefcEWAPt1AfwZjBBWTKadOm1xUcUMnfFukhQ==",
       "requires": {
         "affine-hull": "^1.0.0",
         "incremental-convex-hull": "^1.0.1",
@@ -1207,11 +996,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1220,17 +1004,63 @@
     "country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
-      "integrity": "sha1-UcMz3N8Sknt+XuucEKyBEqYSCJY="
+      "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA=="
+    },
+    "css-font": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
+      "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
+      "requires": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "pick-by-alias": "^1.2.0",
+        "string-split-by": "^1.0.0",
+        "unquote": "^1.1.0"
+      }
+    },
+    "css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q=="
+    },
+    "css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg=="
+    },
+    "css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg=="
+    },
+    "css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA=="
+    },
+    "css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ=="
+    },
+    "css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA=="
     },
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
-      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w=="
     },
     "cubic-hermite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cubic-hermite/-/cubic-hermite-1.0.0.tgz",
-      "integrity": "sha1-hOOy8nKzFFToOTuZu2rtRRaMFOU="
+      "integrity": "sha512-DKZ6yLcJiJJgl54mGA4n0uueYB4qdPfOJrQ1HSEZqdKp6D25AAAWVDwpoAxLflOku5a/ALBO77oEIyWcVa+UYg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -1241,53 +1071,27 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "cwise": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/cwise/-/cwise-1.0.10.tgz",
-      "integrity": "sha1-JO7mBy69/WuMb12tsXCQtkmxK+8=",
-      "requires": {
-        "cwise-compiler": "^1.1.1",
-        "cwise-parser": "^1.0.0",
-        "static-module": "^1.0.0",
-        "uglify-js": "^2.6.0"
-      }
-    },
     "cwise-compiler": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
-      "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
+      "integrity": "sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==",
       "requires": {
         "uniq": "^1.0.0"
-      }
-    },
-    "cwise-parser": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cwise-parser/-/cwise-parser-1.0.3.tgz",
-      "integrity": "sha1-jkk8F9VPl8sDCp6YVLyGyd+zVP4=",
-      "requires": {
-        "esprima": "^1.0.3",
-        "uniq": "^1.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-          "integrity": "sha1-CZNQL+r2aBODJXVvMPmlH+7sEek="
-        }
       }
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "d3": {
       "version": "3.5.17",
       "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
-      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+      "integrity": "sha512-yFk/2idb8OHPKkbAL8QaOaqENNoMhIaSHZerk3oQsECwkObkCpJyjYwCe+OHiq6UEdhe1m8ZGARRRO3ljFjlKg=="
     },
     "d3-array": {
       "version": "1.2.4",
@@ -1300,19 +1104,19 @@
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A=="
     },
     "d3-color": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.3.tgz",
-      "integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
+      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q=="
     },
     "d3-dispatch": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.5.tgz",
-      "integrity": "sha512-vwKx+lAqB1UuCeklr6Jh1bvC4SZgbSqbkGBLClItFBIYH4vqDJCA7qfoy14lXmJdnBOdxndAMxjCbImJYW7e6g=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
+      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA=="
     },
     "d3-force": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.1.2.tgz",
-      "integrity": "sha512-p1vcHAUF1qH7yR+e8ip7Bs61AHjLeKkIn8Z2gzwU2lwEf2wkSpWdjXG0axudTHsVFnYGlMkFaEsVy2l8tAg1Gw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
+      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "requires": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -1320,23 +1124,54 @@
         "d3-timer": "1"
       }
     },
+    "d3-hierarchy": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
+      "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ=="
+    },
     "d3-interpolate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz",
-      "integrity": "sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
+      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
       "requires": {
         "d3-color": "1"
       }
     },
+    "d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+    },
     "d3-quadtree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.5.tgz",
-      "integrity": "sha512-U2tjwDFbZ75JRAg8A+cqMvqPg1G3BE7UTJn3h8DHjY/pnsAfWdbJKgyfcy7zKjqGtLAmI0q8aDSeG1TVIKRaHQ=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
+      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA=="
+    },
+    "d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "requires": {
+        "d3-path": "1"
+      }
+    },
+    "d3-time": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
+      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
+    },
+    "d3-time-format": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
+      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "requires": {
+        "d3-time": "1"
+      }
     },
     "d3-timer": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.9.tgz",
-      "integrity": "sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
+      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw=="
     },
     "dateformat": {
       "version": "2.2.0",
@@ -1356,7 +1191,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -1364,15 +1200,10 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
-    },
     "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
     "defaults": {
       "version": "1.0.3",
@@ -1381,14 +1212,6 @@
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
-      }
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "requires": {
-        "object-keys": "^1.0.12"
       }
     },
     "define-property": {
@@ -1439,14 +1262,14 @@
       }
     },
     "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q=="
     },
     "delaunay-triangulate": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/delaunay-triangulate/-/delaunay-triangulate-1.1.6.tgz",
-      "integrity": "sha1-W7yiGweBmNS8PHV5ajXLuYwllUw=",
+      "integrity": "sha512-mhAclqFCgLoiBIDQDIz2K+puZq6OhYxunXrG2wtTcZS+S1xuzl+H3h0MIOajpES+Z+jfY/rz0wVt3o5iipt1wg==",
       "requires": {
         "incremental-convex-hull": "^1.0.1",
         "uniq": "^1.0.1"
@@ -1464,15 +1287,20 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "detect-kerning": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
+      "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw=="
+    },
     "double-bits": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/double-bits/-/double-bits-1.1.1.tgz",
-      "integrity": "sha1-WKu6RUlNpND6Nrc60RoobJGEscY="
+      "integrity": "sha512-BCLEIBq0O/DWoA7BsCu/R+RP0ZXiowP8BhtJT3qeuuQEBpnS8LK/Wo6UTJQv6v8mK1fj8n90YziHLwGdM5whSg=="
     },
     "draw-svg-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
-      "integrity": "sha1-bxFtli3TFLmepTTW9Y3WbNvWk3k=",
+      "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
       "requires": {
         "abs-svg-path": "~0.1.1",
         "normalize-svg-path": "~0.1.0"
@@ -1481,17 +1309,18 @@
     "dtype": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
-      "integrity": "sha1-zQUjI84GFETs0uj1dI9popvihDQ="
+      "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg=="
     },
     "dup": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
-      "integrity": "sha1-UfxaxoX4GWRp3wuQXpNLIK9bQCk="
+      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA=="
     },
     "duplexer2": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
       "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
       "requires": {
         "readable-stream": "~1.1.9"
       },
@@ -1500,6 +1329,7 @@
           "version": "1.1.14",
           "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -1510,9 +1340,9 @@
       }
     },
     "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -1523,12 +1353,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.8",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -1550,14 +1380,14 @@
       }
     },
     "earcut": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.1.3.tgz",
-      "integrity": "sha512-AxdCdWUk1zzK/NuZ7e1ljj6IGC+VAdC3Qb7QQDsXpfNrc5IM8tL9nNXUmEGE6jRHTfZ10zhzRhtDmWVsR5pd3A=="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "edges-to-adjacency-list": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/edges-to-adjacency-list/-/edges-to-adjacency-list-1.0.0.tgz",
-      "integrity": "sha1-wUbS4ISt37p0pRKTxuAZmkn3V/E=",
+      "integrity": "sha512-0n0Z+xTLfg96eYXm91PEY4rO4WGxohLWjJ9qD1RI3fzxKU6GHez+6KPajpobR4zeZxp7rSiHjHG5dZPj8Kj58Q==",
       "requires": {
         "uniq": "^1.0.0"
       }
@@ -1565,12 +1395,20 @@
     "element-size": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
-      "integrity": "sha1-ZOXxWdlxIWMYRby67K8nnDm1404="
+      "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ=="
+    },
+    "elementary-circuits-directed-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
+      "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
+      "requires": {
+        "strongly-connected-components": "^1.0.1"
+      }
     },
     "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -1584,42 +1422,20 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-      "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "es5-ext": {
-      "version": "0.10.46",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+      "version": "0.10.62",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
+      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
       "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
       }
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "requires": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -1627,41 +1443,42 @@
       }
     },
     "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
+      "version": "4.2.8",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
       "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
       }
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "requires": {
-        "esprima": "^3.1.3",
+        "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
         "optionator": "^0.8.1",
@@ -1669,32 +1486,24 @@
       }
     },
     "esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-    },
-    "espurify": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
-      "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
-      "requires": {
-        "core-js": "^2.0.0"
-      }
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "events": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "version": "3.3.0",
+      "resolved": "http://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -1731,10 +1540,20 @@
         "homedir-polyfill": "^1.0.1"
       }
     },
-    "expect.js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.2.0.tgz",
-      "integrity": "sha1-EChTPSwcNj90pnlv9X7AUg3tK+E="
+    "ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "requires": {
+        "type": "^2.7.2"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
+          "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
+        }
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -1746,6 +1565,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
       "requires": {
         "is-extendable": "^0.1.0"
       }
@@ -1815,17 +1635,22 @@
     "extract-frustum-planes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/extract-frustum-planes/-/extract-frustum-planes-1.0.0.tgz",
-      "integrity": "sha1-l9VwP/BWTIw8aDjKxF+ee8UsnvU="
+      "integrity": "sha512-GivvxEMgjSNnB3e1mIMBlB5ogPB6XyEjOQRGG0SfYVVLtu1ntLGHLT1ly8+mE819dKBHBwnm9+UBCScjiMgppA=="
     },
     "falafel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
-      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
+      "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
       "requires": {
-        "acorn": "^5.0.0",
-        "foreach": "^2.0.5",
-        "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
+        "acorn": "^7.1.1",
+        "isarray": "^2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
       }
     },
     "fancy-log": {
@@ -1840,9 +1665,9 @@
       }
     },
     "fast-isnumeric": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.2.tgz",
-      "integrity": "sha512-D7zJht1+NZBBv4759yXn/CJFUNJpILdgdosPFN1AjqQn9TfQJqSeCZfu0SY4bwIlXuDhzkxKoQ8BOqdiXpVzvA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
+      "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
       "requires": {
         "is-string-blank": "^1.0.1"
       }
@@ -1850,7 +1675,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
     },
     "filesize": {
       "version": "2.0.4",
@@ -1871,11 +1696,11 @@
       }
     },
     "filtered-vector": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.4.tgz",
-      "integrity": "sha1-VkU8A030MC0pPKjs3qw/kKvGeNM=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/filtered-vector/-/filtered-vector-1.2.5.tgz",
+      "integrity": "sha512-5Vu6wdtQJ1O2nRmz39dIr9m3hEDq1skYby5k1cJQdNWK4dMgvYcUEiA/9j7NcKfNZ5LGxn8w2LSLiigyH7pTAw==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
+        "binary-search-bounds": "^2.0.0",
         "cubic-hermite": "^1.0.0"
       }
     },
@@ -1940,37 +1765,20 @@
         "dtype": "^2.0.0"
       }
     },
-    "flow-remove-types": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-1.2.3.tgz",
-      "integrity": "sha512-ypq/U3V+t9atYiOuSJd40tekCra03EHKoRsiK/wXGrsZimuum0kdwVY7Yv0HTaoXgHW1WiayomYd+Q3kkvPl9Q==",
+    "font-atlas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
+      "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "requires": {
-        "babylon": "^6.15.0",
-        "vlq": "^0.2.1"
-      },
-      "dependencies": {
-        "vlq": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
-        }
+        "css-font": "^1.0.0"
       }
     },
-    "font-atlas-sdf": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/font-atlas-sdf/-/font-atlas-sdf-1.3.3.tgz",
-      "integrity": "sha512-GxUpcdkdoHgC3UrpMuA7JmG1Ty/MY0BhfmV8r7ZSv3bkqBY5vmRIjcj7Pg8iqj20B03vlU6fUhdpyIgEo/Z35w==",
+    "font-measure": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
+      "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
       "requires": {
-        "optical-properties": "^1.0.0",
-        "tiny-sdf": "^1.0.2"
-      }
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "requires": {
-        "is-callable": "^1.1.3"
+        "css-font": "^1.2.0"
       }
     },
     "for-in": {
@@ -1988,11 +1796,6 @@
         "for-in": "^1.0.1"
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -2005,7 +1808,7 @@
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -2014,12 +1817,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.8",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2043,22 +1846,18 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g=="
     },
     "gamma": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/gamma/-/gamma-0.1.0.tgz",
-      "integrity": "sha1-MxVkNAO/J5BsqAqzfDbs6UQO8zA="
+      "integrity": "sha512-IgHc/jnzNTA2KjXmRSx/CVd1ONp7HTAV81SLI+n3G6PyyHkakkE+2d3hteJYFm7aoe01NEl4m7ziUAsoWCc5AA=="
     },
     "gaze": {
       "version": "0.5.2",
@@ -2069,17 +1868,6 @@
         "globule": "~0.1.0"
       }
     },
-    "geojson-rewind": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/geojson-rewind/-/geojson-rewind-0.3.1.tgz",
-      "integrity": "sha1-IiQHl8hHzC8MHTE+SqDJFa+n8p0=",
-      "requires": {
-        "@mapbox/geojson-area": "0.2.2",
-        "concat-stream": "~1.6.0",
-        "minimist": "1.2.0",
-        "sharkdown": "^0.1.0"
-      }
-    },
     "geojson-vt": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
@@ -2088,13 +1876,18 @@
     "get-canvas-context": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
-      "integrity": "sha1-1ue1C8TkyGNXzTnyJkeoS3NgHpM="
+      "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A=="
     },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
     },
     "get-value": {
       "version": "2.0.6",
@@ -2103,79 +1896,91 @@
       "dev": true
     },
     "gl-axes3d": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.3.2.tgz",
-      "integrity": "sha512-djAEyX7pz1C9CICos300JNAbdsFHCb2oWXAg1d/Zge+8VgUg+QayfQemHhVv8JVbcoWulnvZp8K+yQEBnCEhPw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/gl-axes3d/-/gl-axes3d-1.5.3.tgz",
+      "integrity": "sha512-KRYbguKQcDQ6PcB9g1pgqB8Ly4TY1DQODpPKiDTasyWJ8PxQk0t2Q7XoQQijNqvsguITCpVVCzNb5GVtIWiVlQ==",
       "requires": {
-        "bit-twiddle": "^1.0.0",
+        "bit-twiddle": "^1.0.2",
         "dup": "^1.0.0",
         "extract-frustum-planes": "^1.0.0",
-        "gl-buffer": "^2.0.3",
-        "gl-mat4": "^1.0.1",
-        "gl-shader": "^4.0.4",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
         "gl-state": "^1.0.0",
-        "gl-vao": "^1.1.1",
+        "gl-vao": "^1.3.0",
         "gl-vec4": "^1.0.1",
-        "glslify": "^6.1.0",
+        "glslify": "^7.0.0",
         "robust-orientation": "^1.1.3",
         "split-polygon": "^1.0.0",
-        "vectorize-text": "^3.0.0"
+        "vectorize-text": "^3.2.1"
       }
     },
     "gl-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/gl-buffer/-/gl-buffer-2.1.2.tgz",
-      "integrity": "sha1-LbjZwaVSf7oM25EonCBuiCuInNs=",
+      "integrity": "sha512-uVvLxxhEbQGl43xtDeKu75ApnrGyNHoPmOcvvuJNyP04HkK0/sX5Dll6OFffQiwSV4j0nlAZsgznvO3CPT3dFg==",
       "requires": {
         "ndarray": "^1.0.15",
         "ndarray-ops": "^1.1.0",
         "typedarray-pool": "^1.0.0"
       }
     },
+    "gl-cone3d": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/gl-cone3d/-/gl-cone3d-1.5.2.tgz",
+      "integrity": "sha512-1JNeHH4sUtUmDA4ZK7Om8/kShwb8IZVAsnxaaB7IPRJsNGciLj1sTpODrJGeMl41RNkex5kXD2SQFrzyEAR2Rw==",
+      "requires": {
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "gl-vec3": "^1.1.3",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
+      }
+    },
     "gl-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
-      "integrity": "sha1-WXpQTjZHUP9QJTqjX43qevSl0jM="
+      "integrity": "sha512-3DNyoAUdb1c+o7jNk5Nm7eh6RSQFi9ZmMQIQb2xxsO27rUopE+IUhoh4xlUvZYBn1YPgUC8BlCnrVjXq/d2dQA=="
     },
     "gl-contour2d": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.4.tgz",
-      "integrity": "sha512-deoY6k5ZcQfh5brlF3nXKs8FqhMNejlxIqWcK+bKenLcThJF94OR7DtQDwLwNXsYAZlsoDt+G01efXid6Modkg==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/gl-contour2d/-/gl-contour2d-1.1.7.tgz",
+      "integrity": "sha512-GdebvJ9DtT3pJDpoE+eU2q+Wo9S3MijPpPz5arZbhK85w2bARmpFpVfPaDlZqWkB644W3BlH8TVyvAo1KE4Bhw==",
       "requires": {
-        "binary-search-bounds": "^2.0.0",
+        "binary-search-bounds": "^2.0.4",
         "cdt2d": "^1.0.0",
-        "clean-pslg": "^1.1.0",
+        "clean-pslg": "^1.1.2",
         "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.5",
-        "glslify": "^6.1.0",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
         "iota-array": "^1.0.0",
         "ndarray": "^1.0.18",
         "surface-nets": "^1.0.2"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
       }
     },
     "gl-error3d": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.8.tgz",
-      "integrity": "sha512-BAps+MLAknIOdWOE+YJGr/Ie1d+y18jA+Y7js/NOO0V5bCHbJry2Mb/3W9da6wRzxxQOFYM6upKux1eL+ZKzww==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/gl-error3d/-/gl-error3d-1.0.16.tgz",
+      "integrity": "sha512-TGJewnKSp7ZnqGgG3XCF9ldrDbxZrO+OWlx6oIet4OdOM//n8xJ5isArnIV/sdPJnFbhfoLxWrW9f5fxHFRQ1A==",
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
         "gl-vao": "^1.3.0",
-        "glsl-out-of-range": "^1.0.2",
-        "glslify": "^6.0.2"
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0"
       }
     },
     "gl-fbo": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/gl-fbo/-/gl-fbo-2.0.5.tgz",
-      "integrity": "sha1-D6daSXz3h2lVMGkcjwSrtvtV+iI=",
+      "integrity": "sha512-tDq6zQSQzvvK2QwPV7ln7cf3rs0jV1rQXqKOEuB145LdN+xhADPBtXHDJ3Ftk80RAJimJU0AaQBgP/X6yYGNhQ==",
       "requires": {
         "gl-texture2d": "^2.0.0"
       }
@@ -2183,7 +1988,7 @@
     "gl-format-compiler-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
-      "integrity": "sha1-DHmxdRiZzpcy6GJA8JCqQemEcag=",
+      "integrity": "sha512-FtQaBYlsM/rnz7YhLkxG9dLcNDB+ExErIsFV2DXl0nk+YgIZ2i0jMob4BrhT9dNa179zFb0gZMWpNAokytK+Ug==",
       "requires": {
         "add-line-numbers": "^1.0.1",
         "gl-constants": "^1.0.0",
@@ -2192,144 +1997,122 @@
       }
     },
     "gl-heatmap2d": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.0.4.tgz",
-      "integrity": "sha512-AWJykMTbCM0ZT20jiFaauRVmLv9dxtNNuTS1NQlKD8yBD0iZ62mgWLeYLUMjil6XN8K3P9EpUCBolvcx1Wf0kA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gl-heatmap2d/-/gl-heatmap2d-1.1.1.tgz",
+      "integrity": "sha512-6Vo1fPIB1vQFWBA/MR6JAA16XuQuhwvZRbSjYEq++m4QV33iqjGS2HcVIRfJGX+fomd5eiz6bwkVZcKm69zQPw==",
       "requires": {
-        "binary-search-bounds": "^2.0.3",
+        "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.5",
-        "glslify": "^6.1.0",
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0",
         "iota-array": "^1.0.0",
-        "typedarray-pool": "^1.1.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
+        "typedarray-pool": "^1.2.0"
       }
     },
     "gl-line3d": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.1.5.tgz",
-      "integrity": "sha512-l0M/prZfiUtG1jh+1TsJw3H0DbifSU4Wqeni6o0iFwwLuz/FL/IbWbYY6LufV3jWHMt7Oc7Nj/YwiK+m4vBPgg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/gl-line3d/-/gl-line3d-1.2.1.tgz",
+      "integrity": "sha512-eeb0+RI2ZBRqMYJK85SgsRiJK7c4aiOjcnirxv0830A3jmOc99snY3AbPcV8KvKmW0Yaf3KA4e+qNCbHiTOTnA==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
-        "gl-buffer": "^2.0.8",
+        "binary-search-bounds": "^2.0.4",
+        "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.2",
-        "gl-vao": "^1.1.3",
-        "glsl-out-of-range": "^1.0.2",
-        "glsl-read-float": "^1.0.0",
-        "glslify": "^6.1.0",
-        "ndarray": "^1.0.16"
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18"
       }
-    },
-    "gl-mat2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gl-mat2/-/gl-mat2-1.0.1.tgz",
-      "integrity": "sha1-FCUFcwpcL+Hp8l2ezj0NbMJxCjA="
     },
     "gl-mat3": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-mat3/-/gl-mat3-1.0.0.tgz",
-      "integrity": "sha1-iWMyGcpCk3mha5GF2V1BcTRTuRI="
+      "integrity": "sha512-obeEq9y7xaDoVkwMGJNL1upwpYlPJiXJFhREaNytMqUdfHKHNna9HvImmLV8F8Ys6QOYwPPddptZNoiiec/XOg=="
     },
     "gl-mat4": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
       "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA=="
     },
-    "gl-matrix-invert": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gl-matrix-invert/-/gl-matrix-invert-1.0.0.tgz",
-      "integrity": "sha1-o2173jZUxFkKEn7nxo9uE/6oxj0=",
-      "requires": {
-        "gl-mat2": "^1.0.0",
-        "gl-mat3": "^1.0.0",
-        "gl-mat4": "^1.0.0"
-      }
+    "gl-matrix": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
+      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA=="
     },
     "gl-mesh3d": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.0.1.tgz",
-      "integrity": "sha512-9oc1qGQ36tBQg7M0YztgRfa90ShLJyJC3iyJIV9tCQ6X1/4JiEqFc9Uu+/hCT/dW4kd8ZwkLPKEICqIM7LkEMw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/gl-mesh3d/-/gl-mesh3d-2.3.1.tgz",
+      "integrity": "sha512-pXECamyGgu4/9HeAQSE5OEUuLBGS1aq9V4BCsTcxsND4fNLaajEkYKUz/WY2QSYElqKdsMBVsldGiKRKwlybqA==",
       "requires": {
         "barycentric": "^1.0.1",
-        "colormap": "^2.1.0",
-        "gl-buffer": "^2.0.8",
-        "gl-mat4": "^1.0.0",
+        "colormap": "^2.3.1",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
         "gl-shader": "^4.2.1",
-        "gl-texture2d": "^2.0.8",
-        "gl-vao": "^1.1.3",
-        "glsl-face-normal": "^1.0.2",
-        "glsl-out-of-range": "^1.0.2",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
         "glsl-specular-cook-torrance": "^2.0.1",
-        "glslify": "^6.1.0",
-        "ndarray": "^1.0.15",
-        "normals": "^1.0.1",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18",
+        "normals": "^1.1.0",
         "polytope-closest-point": "^1.0.0",
-        "simplicial-complex-contour": "^1.0.0",
+        "simplicial-complex-contour": "^1.0.2",
         "typedarray-pool": "^1.1.0"
       }
     },
     "gl-plot2d": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.3.1.tgz",
-      "integrity": "sha512-wmZC1ztzkWP03J/1W6yenHwu9c3YzBslIoj/qywkrtO8BXsZeXNAQUidJ2Iq9yvphbOWB3dV0IByNVKKUh3CWw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/gl-plot2d/-/gl-plot2d-1.4.5.tgz",
+      "integrity": "sha512-6GmCN10SWtV+qHFQ1gjdnVubeHFVsm6P4zmo0HrPIl9TcdePCUHDlBKWAuE6XtFhiMKMj7R8rApOX8O8uXUYog==",
       "requires": {
-        "binary-search-bounds": "^2.0.3",
+        "binary-search-bounds": "^2.0.4",
         "gl-buffer": "^2.1.2",
-        "gl-select-static": "^2.0.2",
+        "gl-select-static": "^2.0.7",
         "gl-shader": "^4.2.1",
         "glsl-inverse": "^1.0.0",
-        "glslify": "^6.1.0",
-        "text-cache": "^4.1.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
+        "glslify": "^7.0.0",
+        "text-cache": "^4.2.2"
       }
     },
     "gl-plot3d": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-1.5.10.tgz",
-      "integrity": "sha512-CgmfW0ssqmvluSc/C74k3xJaBXB2kZq7gvkrPfLhj5OSxnJORSX0ACf+Sl6Cv8YrfX/5EzQvyT67d+rhtlBmEg==",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/gl-plot3d/-/gl-plot3d-2.4.7.tgz",
+      "integrity": "sha512-mLDVWrl4Dj0O0druWyHUK5l7cBQrRIJRn2oROEgrRuOgbbrLAzsREKefwMO0bA0YqkiZMFMnV5VvPA9j57X5Xg==",
       "requires": {
-        "3d-view-controls": "^2.2.0",
-        "a-big-triangle": "^1.0.0",
-        "gl-axes3d": "^1.3.2",
-        "gl-fbo": "^2.0.3",
-        "gl-mat4": "^1.1.2",
-        "gl-select-static": "^2.0.2",
+        "3d-view": "^2.0.0",
+        "a-big-triangle": "^1.0.3",
+        "gl-axes3d": "^1.5.3",
+        "gl-fbo": "^2.0.5",
+        "gl-mat4": "^1.2.0",
+        "gl-select-static": "^2.0.7",
         "gl-shader": "^4.2.1",
-        "gl-spikes3d": "^1.0.3",
-        "glslify": "^6.1.0",
-        "is-mobile": "^2.0.0",
-        "mouse-change": "^1.1.1",
-        "ndarray": "^1.0.16"
+        "gl-spikes3d": "^1.0.10",
+        "glslify": "^7.0.0",
+        "has-passive-events": "^1.0.0",
+        "is-mobile": "^2.2.1",
+        "mouse-change": "^1.4.0",
+        "mouse-event-offset": "^3.0.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.19",
+        "right-now": "^1.0.0"
       }
     },
     "gl-pointcloud2d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.1.tgz",
-      "integrity": "sha512-bCNaPSrZjBiKRrlbhHdipnmTc5xteubksevbPrmdlk2R6PTwQlQ38TDxuRYan02j0uDtem9wEp8etYYMjZFMhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-pointcloud2d/-/gl-pointcloud2d-1.0.3.tgz",
+      "integrity": "sha512-OS2e1irvJXVRpg/GziXj10xrFJm9kkRfFoB6BLUvkjCQV7ZRNNcs2CD+YSK1r0gvMwTg2T3lfLM3UPwNtz+4Xw==",
       "requires": {
         "gl-buffer": "^2.1.2",
         "gl-shader": "^4.2.1",
-        "glslify": "^6.1.0",
+        "glslify": "^7.0.0",
         "typedarray-pool": "^1.1.0"
       }
     },
     "gl-quat": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-quat/-/gl-quat-1.0.0.tgz",
-      "integrity": "sha1-CUXskjOG9FMpvl3DV7HIwtR1hsU=",
+      "integrity": "sha512-Pv9yvjJgQN85EbE79S+DF50ujxDkyjfYHIyXJcCRiimU1UxMY7vEHbVkj0IWLFaDndhfZT9vVOyfdMobLlrJsQ==",
       "requires": {
         "gl-mat3": "^1.0.0",
         "gl-vec3": "^1.0.3",
@@ -2337,116 +2120,174 @@
       }
     },
     "gl-scatter3d": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.0.14.tgz",
-      "integrity": "sha512-fF1XvHqQ68bAOBVXkG+1E67nbpj1lpJmSEGKRGep4PlndSlLQEXKephyhBPtOGk32/OEOWr4SamIBxRhlu882Q==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/gl-scatter3d/-/gl-scatter3d-1.2.3.tgz",
+      "integrity": "sha512-nXqPlT1w5Qt51dTksj+DUqrZqwWAEWg0PocsKcoDnVNv0X8sGA+LBZ0Y+zrA+KNXUL0PPCX9WR9cF2uJAZl1Sw==",
       "requires": {
-        "gl-buffer": "^2.0.6",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.0",
-        "gl-vao": "^1.1.2",
-        "glsl-out-of-range": "^1.0.2",
-        "glslify": "^6.1.0",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glslify": "^7.0.0",
         "is-string-blank": "^1.0.1",
-        "typedarray-pool": "^1.0.2",
-        "vectorize-text": "^3.0.0"
+        "typedarray-pool": "^1.1.0",
+        "vectorize-text": "^3.2.1"
       }
     },
     "gl-select-box": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.2.tgz",
-      "integrity": "sha512-QCheTcyHiamTgOQ92P9swHgJoR25T8GGRCANASRtjdMXndlAbQG4qxBP15MRJx7RFWlOVvEeUzCvPn7r116orA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/gl-select-box/-/gl-select-box-1.0.4.tgz",
+      "integrity": "sha512-mKsCnglraSKyBbQiGq0Ila0WF+m6Tr+EWT2yfaMn/Sh9aMHq5Wt0F/l6Cf/Ed3CdERq5jHWAY5yxLviZteYu2w==",
       "requires": {
         "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.5",
-        "glslify": "^6.1.0"
+        "gl-shader": "^4.2.1",
+        "glslify": "^7.0.0"
       }
     },
     "gl-select-static": {
-      "version": "2.0.2",
-      "resolved": "http://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.2.tgz",
-      "integrity": "sha1-8+GQHfAxgdUy55WFMjBnnUr1fuk=",
+      "version": "2.0.7",
+      "resolved": "http://registry.npmjs.org/gl-select-static/-/gl-select-static-2.0.7.tgz",
+      "integrity": "sha512-OvpYprd+ngl3liEatBTdXhSyNBjwvjMSvV2rN0KHpTU+BTi4viEETXNZXFgGXY37qARs0L28ybk3UQEW6C5Nnw==",
       "requires": {
         "bit-twiddle": "^1.0.2",
-        "cwise": "^1.0.3",
-        "gl-fbo": "^2.0.3",
-        "ndarray": "^1.0.15",
+        "gl-fbo": "^2.0.5",
+        "ndarray": "^1.0.18",
         "typedarray-pool": "^1.1.0"
       }
     },
     "gl-shader": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.2.1.tgz",
-      "integrity": "sha1-vJuAjpKTxRtmjojeYVsMETcI3C8=",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.3.1.tgz",
+      "integrity": "sha512-xLoN6XtRLlg97SEqtuzfKc+pVWpVkQ3YjDI1kuCale8tF7+zMhiKlMfmG4IMQPMdKJZQbIc/Ny8ZusEpfh5U+w==",
       "requires": {
         "gl-format-compiler-error": "^1.0.2",
         "weakmap-shim": "^1.1.0"
       }
     },
     "gl-spikes2d": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.1.tgz",
-      "integrity": "sha1-ys2y09vNICuFNFLoUAqLB3lJzAM="
+      "version": "1.0.2",
+      "resolved": "http://registry.npmjs.org/gl-spikes2d/-/gl-spikes2d-1.0.2.tgz",
+      "integrity": "sha512-QVeOZsi9nQuJJl7NB3132CCv5KA10BWxAY2QgJNsKqbLsG53B/TrGJpjIAohnJftdZ4fT6b3ZojWgeaXk8bOOA=="
     },
     "gl-spikes3d": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.6.tgz",
-      "integrity": "sha512-mXRG+3iCs4bDH7if2aOr1G5UpbNqKxfWpy7GR/afOHDSNsrq2ZjnWAwPmIJG7KdClPNPgiK30cVo7XisLt8PCQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/gl-spikes3d/-/gl-spikes3d-1.0.10.tgz",
+      "integrity": "sha512-lT3xroowOFxMvlhT5Mof76B2TE02l5zt/NIWljhczV2FFHgIVhA4jMrd5dIv1so1RXMBDJIKu0uJI3QKliDVLg==",
       "requires": {
         "gl-buffer": "^2.1.2",
-        "gl-shader": "^4.0.4",
-        "gl-vao": "^1.2.1",
-        "glslify": "^6.1.0"
+        "gl-shader": "^4.2.1",
+        "gl-vao": "^1.3.0",
+        "glslify": "^7.0.0"
       }
     },
     "gl-state": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gl-state/-/gl-state-1.0.0.tgz",
-      "integrity": "sha1-Ji+qdYNbC5xTLBLzitxCXR0wzRc=",
+      "integrity": "sha512-Od836PpgCuTC0W7uHYnEEPRdQPL1FakWlznz3hRvlO6tD5sdLfBKX9qNRGy1DjfMCDTudhyYWxiWjhql1B8N4Q==",
       "requires": {
         "uniq": "^1.0.0"
       }
     },
-    "gl-surface3d": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.3.6.tgz",
-      "integrity": "sha512-aNCCee0vU3JW6iQmsFUXl5QNu4VXx6OF/rZAfgOM38BxJxnCcFZg+NUXA+S2cyWG4cEEjw8zDqaED0OvX6aj+w==",
+    "gl-streamtube3d": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gl-streamtube3d/-/gl-streamtube3d-1.4.1.tgz",
+      "integrity": "sha512-rH02v00kgwgdpkXVo7KsSoPp38bIAYR9TE1iONjcQ4cQAlDhrGRauqT/P5sUaOIzs17A2DxWGcXM+EpNQs9pUA==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
+        "gl-cone3d": "^1.5.2",
+        "gl-vec3": "^1.1.3",
+        "gl-vec4": "^1.0.1",
+        "glsl-inverse": "^1.0.0",
+        "glsl-out-of-range": "^1.0.4",
+        "glsl-specular-cook-torrance": "^2.0.1",
+        "glslify": "^7.0.0"
+      }
+    },
+    "gl-surface3d": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gl-surface3d/-/gl-surface3d-1.6.0.tgz",
+      "integrity": "sha512-x15+u4712ysnB85G55RLJEml6mOB4VaDn0VTlXCc9JcjRl5Es10Tk7lhGGyiPtkCfHwvhnkxzYA1/rHHYN7Y0A==",
+      "requires": {
+        "binary-search-bounds": "^2.0.4",
         "bit-twiddle": "^1.0.2",
-        "colormap": "^2.1.0",
+        "colormap": "^2.3.1",
         "dup": "^1.0.0",
-        "gl-buffer": "^2.0.3",
-        "gl-mat4": "^1.0.0",
-        "gl-shader": "^4.2.0",
-        "gl-texture2d": "^2.0.0",
-        "gl-vao": "^1.1.1",
-        "glsl-out-of-range": "^1.0.2",
+        "gl-buffer": "^2.1.2",
+        "gl-mat4": "^1.2.0",
+        "gl-shader": "^4.2.1",
+        "gl-texture2d": "^2.1.0",
+        "gl-vao": "^1.3.0",
+        "glsl-out-of-range": "^1.0.4",
         "glsl-specular-beckmann": "^1.1.2",
-        "glslify": "^6.1.0",
-        "ndarray": "^1.0.16",
+        "glslify": "^7.0.0",
+        "ndarray": "^1.0.18",
         "ndarray-gradient": "^1.0.0",
-        "ndarray-ops": "^1.2.1",
-        "ndarray-pack": "^1.0.1",
-        "ndarray-scratch": "^1.1.1",
+        "ndarray-ops": "^1.2.2",
+        "ndarray-pack": "^1.2.1",
+        "ndarray-scratch": "^1.2.0",
         "surface-nets": "^1.0.2",
-        "typedarray-pool": "^1.0.0"
+        "typedarray-pool": "^1.1.0"
+      }
+    },
+    "gl-text": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.3.1.tgz",
+      "integrity": "sha512-/f5gcEMiZd+UTBJLTl3D+CkCB/0UFGTx3nflH8ZmyWcLkZhsZ1+Xx5YYkw2rgWAzgPeE35xCqBuHSoMKQVsR+w==",
+      "requires": {
+        "bit-twiddle": "^1.0.2",
+        "color-normalize": "^1.5.0",
+        "css-font": "^1.2.0",
+        "detect-kerning": "^2.1.2",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "font-atlas": "^2.1.0",
+        "font-measure": "^1.2.2",
+        "gl-util": "^3.1.2",
+        "is-plain-obj": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "parse-rect": "^1.2.0",
+        "parse-unit": "^1.0.1",
+        "pick-by-alias": "^1.2.0",
+        "regl": "^2.0.0",
+        "to-px": "^1.0.1",
+        "typedarray-pool": "^1.1.0"
+      },
+      "dependencies": {
+        "regl": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.0.tgz",
+          "integrity": "sha512-oWUce/aVoEvW5l2V0LK7O5KJMzUSKeiOwFuJehzpSFd43dO5spP9r+sSUfhKtsky4u6MCqWJaRL+abzExynfTg=="
+        }
       }
     },
     "gl-texture2d": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gl-texture2d/-/gl-texture2d-2.1.0.tgz",
-      "integrity": "sha1-/2gk5+fDGoum/c2+nlxpXX4hh8c=",
+      "integrity": "sha512-W0tzEjtlGSsCKq5FFwFVhH+fONFUTUeqM4HhA/BleygKaX39IwNTVOiqkwfu9szQZ4dQEq8ZDl7w1ud/eKLaZA==",
       "requires": {
         "ndarray": "^1.0.15",
         "ndarray-ops": "^1.2.2",
         "typedarray-pool": "^1.1.0"
       }
     },
+    "gl-util": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
+      "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
+      "requires": {
+        "is-browser": "^2.0.1",
+        "is-firefox": "^1.0.3",
+        "is-plain-obj": "^1.1.0",
+        "number-is-integer": "^1.0.1",
+        "object-assign": "^4.1.0",
+        "pick-by-alias": "^1.2.0",
+        "weak-map": "^1.0.5"
+      }
+    },
     "gl-vao": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/gl-vao/-/gl-vao-1.3.0.tgz",
-      "integrity": "sha1-6ekqqVWIyrnVwvBLaTRAw99pGSM="
+      "integrity": "sha512-stSOZ+n0fnAxgDfipwKK/73AwzCNL+AFEc/v2Xm76nyFnUZGmQtD2FEC3lt1icoOHAzMgHBAjCue7dBIDeOTcw=="
     },
     "gl-vec3": {
       "version": "1.1.3",
@@ -2456,12 +2297,13 @@
     "gl-vec4": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gl-vec4/-/gl-vec4-1.0.1.tgz",
-      "integrity": "sha1-l9loeCgbFLUyy84QF4Xf0cs0CWQ="
+      "integrity": "sha512-/gx5zzIy75JXzke4yuwcbvK+COWf8UJbVCUPvhfsYVw1GVey4Eextk/0H0ctXnOICruNK7+GS4ILQzEQcHcPEg=="
     },
     "glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2611,15 +2453,10 @@
         "sparkles": "^1.0.0"
       }
     },
-    "glsl-face-normal": {
-      "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/glsl-face-normal/-/glsl-face-normal-1.0.2.tgz",
-      "integrity": "sha1-fud12Rmk8u6S9Xu2mOh8x12/Eog="
-    },
     "glsl-inject-defines": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
-      "integrity": "sha1-3RqswsF/yyvT/DJBHGYz0Ne2D9Q=",
+      "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
       "requires": {
         "glsl-token-inject-block": "^1.0.0",
         "glsl-token-string": "^1.0.1",
@@ -2629,22 +2466,17 @@
     "glsl-inverse": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/glsl-inverse/-/glsl-inverse-1.0.0.tgz",
-      "integrity": "sha1-EsCx0GX1WERNHm/q95td34qRiuY="
+      "integrity": "sha512-+BsseNlgqzd4IFX1dMqg+S0XuIXzH0acvTtW7svwhJESM1jb2BZFwdO+tOWdCXD5Zse6b9bOmzp5sCNA7GQ2QA=="
     },
     "glsl-out-of-range": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.2.tgz",
-      "integrity": "sha512-Qej48sfhSajxvfOmFNz5RV37DEHUjVTz38id1Y/Nt0kAXEe8IQSOXhKvlnD+uDpU5JKS6fLxlxLy8lJ/bepqAQ=="
-    },
-    "glsl-read-float": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/glsl-read-float/-/glsl-read-float-1.1.0.tgz",
-      "integrity": "sha1-37CIsBYtz8xW/E7d0vhuGMrDLyY="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/glsl-out-of-range/-/glsl-out-of-range-1.0.4.tgz",
+      "integrity": "sha512-fCcDu2LCQ39VBvfe1FbhuazXEf0CqMZI9OYXrYlL6uUARG48CTAbL04+tZBtVM0zo1Ljx4OLu2AxNquq++lxWQ=="
     },
     "glsl-resolve": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
-      "integrity": "sha1-iUvvc5ENeSyBtRQxgANdCnivdtM=",
+      "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
       "requires": {
         "resolve": "^0.6.1",
         "xtend": "^2.1.2"
@@ -2653,19 +2485,19 @@
         "resolve": {
           "version": "0.6.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
-          "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY="
+          "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg=="
         },
         "xtend": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
-          "integrity": "sha1-7vax8ZjByN6vrYsXZaBNrUoBxak="
+          "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw=="
         }
       }
     },
     "glsl-shader-name": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
-      "integrity": "sha1-osMLO6c0mb77DMcYTXx3M91LSH0=",
+      "integrity": "sha512-OtHon0dPCbJD+IrVA1vw9QDlp2cS/f9z8X/0y+W7Qy1oZ3U1iFAQUEco2v30V0SAlVLDG5rEfhjEfc3DKdGbFQ==",
       "requires": {
         "atob-lite": "^1.0.0",
         "glsl-tokenizer": "^2.0.2"
@@ -2674,12 +2506,12 @@
     "glsl-specular-beckmann": {
       "version": "1.1.2",
       "resolved": "http://registry.npmjs.org/glsl-specular-beckmann/-/glsl-specular-beckmann-1.1.2.tgz",
-      "integrity": "sha1-/OkFaTPs3yRWJ4N2pU0IKJPndfE="
+      "integrity": "sha512-INvd7szO1twNPLGwE0Kf2xXIEy5wpOPl/LYoiw3+3nbAe6Rfn5rjdK9xvfnwoWksTCs3RejuLeAiZkLTkdFtwg=="
     },
     "glsl-specular-cook-torrance": {
       "version": "2.0.1",
       "resolved": "http://registry.npmjs.org/glsl-specular-cook-torrance/-/glsl-specular-cook-torrance-2.0.1.tgz",
-      "integrity": "sha1-qJHMBsjHtPRyhwK0gk/ay7ln148=",
+      "integrity": "sha512-bFtTfbgLXIbto/U6gM7h0IxoPMU+5zpMK5HoAaA2LnPuGk3JSzKAnsoyh5QGTT8ioIEQrjk6jcQNrgujPsP7rw==",
       "requires": {
         "glsl-specular-beckmann": "^1.1.1"
       }
@@ -2687,12 +2519,12 @@
     "glsl-token-assignments": {
       "version": "2.0.2",
       "resolved": "http://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
-      "integrity": "sha1-pdgqt4SZwuimuDy2lJXm5mXOAZ8="
+      "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ=="
     },
     "glsl-token-defines": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
-      "integrity": "sha1-y4kqqVmTYjFyhHDU90AySJaX+p0=",
+      "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
       "requires": {
         "glsl-tokenizer": "^2.0.0"
       }
@@ -2700,12 +2532,12 @@
     "glsl-token-depth": {
       "version": "1.1.2",
       "resolved": "http://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
-      "integrity": "sha1-I8XjDuK9JViEtKKLyFC495HpXYQ="
+      "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg=="
     },
     "glsl-token-descope": {
       "version": "1.0.2",
       "resolved": "http://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
-      "integrity": "sha1-D8kKsyYYa4L1l7LnfcniHvzTIHY=",
+      "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
       "requires": {
         "glsl-token-assignments": "^2.0.0",
         "glsl-token-depth": "^1.1.0",
@@ -2716,27 +2548,27 @@
     "glsl-token-inject-block": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
-      "integrity": "sha1-4QFfWYDBCRgkraomJfHf3ovQADQ="
+      "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA=="
     },
     "glsl-token-properties": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
-      "integrity": "sha1-SD3D2Dnw1LXGFx0VkfJJvlPCip4="
+      "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA=="
     },
     "glsl-token-scope": {
       "version": "1.1.2",
       "resolved": "http://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
-      "integrity": "sha1-oXKOeN8kRE+cuT/RjvD3VQOmQ7E="
+      "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A=="
     },
     "glsl-token-string": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
-      "integrity": "sha1-WUQdL4V958NEnJRWZgIezjWOSOw="
+      "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg=="
     },
     "glsl-token-whitespace-trim": {
       "version": "1.0.0",
       "resolved": "http://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
-      "integrity": "sha1-RtHf6Yx1vX1QTAXX0RsbPpzJOxA="
+      "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ=="
     },
     "glsl-tokenizer": {
       "version": "2.1.5",
@@ -2747,11 +2579,11 @@
       }
     },
     "glslify": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/glslify/-/glslify-6.4.1.tgz",
-      "integrity": "sha512-YDQ1Lei4Mj0TjJqjbf/llIJ1c10vsUTf6OQZ9N058PnVwOmIZyTmtr5Pgh9i99nxvP4M4sRWA5+IucQuOUnV5w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
+      "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
       "requires": {
-        "bl": "^1.0.0",
+        "bl": "^2.2.1",
         "concat-stream": "^1.5.2",
         "duplexify": "^3.4.5",
         "falafel": "^2.1.0",
@@ -2760,11 +2592,10 @@
         "glsl-token-whitespace-trim": "^1.0.0",
         "glslify-bundle": "^5.0.0",
         "glslify-deps": "^1.2.5",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.5",
         "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
-        "static-eval": "^2.0.0",
-        "tape": "^4.6.0",
+        "static-eval": "^2.0.5",
         "through2": "^2.0.1",
         "xtend": "^4.0.0"
       },
@@ -2772,12 +2603,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
         },
         "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "version": "2.3.8",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -2825,12 +2656,12 @@
       }
     },
     "glslify-deps": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.1.tgz",
-      "integrity": "sha512-Ogm179MCazwIRyEqs3g3EOY4Y3XIAa0yl8J5RE9rJC6QH1w8weVOp2RZu0mvnYy/2xIas1w166YR2eZdDkWQxg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
+      "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
       "requires": {
         "@choojs/findup": "^0.2.0",
-        "events": "^1.0.2",
+        "events": "^3.2.0",
         "glsl-resolve": "0.0.1",
         "glsl-tokenizer": "^2.0.0",
         "graceful-fs": "^4.1.2",
@@ -2850,28 +2681,10 @@
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
       "dev": true
     },
-    "gray-matter": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-3.1.1.tgz",
-      "integrity": "sha512-nZ1qjLmayEv0/wt3sHig7I0s3/sJO0dkAaKYQ5YAOApUtYEOonXSFdWvL1khvnZMTvov4UufkqlFsilPnejEXA==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "js-yaml": "^3.13.1",
-        "kind-of": "^5.0.2",
-        "strip-bom-string": "^1.0.0"
-      },
-      "dependencies": {
-        "kind-of": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-        }
-      }
-    },
     "grid-index": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.0.0.tgz",
-      "integrity": "sha1-rSxdVM5bNUN/r/HXCprrPR0mERA="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "gulp": {
       "version": "3.9.1",
@@ -3076,6 +2889,23 @@
             "multipipe": "^0.1.0",
             "through2": "^0.5.0",
             "vinyl": "^0.2.1"
+          },
+          "dependencies": {
+            "lodash.template": {
+              "version": "2.4.1",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "integrity": "sha512-5yLOQwlS69xbaez3g9dA1i0GMAj8pLDHp8lhA4V7M1vRam1lqD76f0jg5EV+65frbqrXo1WH9ZfKalfYBzJ5yQ==",
+              "dev": true,
+              "requires": {
+                "lodash._escapestringchar": "~2.4.1",
+                "lodash._reinterpolate": "~2.4.1",
+                "lodash.defaults": "~2.4.1",
+                "lodash.escape": "~2.4.1",
+                "lodash.keys": "~2.4.1",
+                "lodash.templatesettings": "~2.4.1",
+                "lodash.values": "~2.4.1"
+              }
+            }
           }
         },
         "has-ansi": {
@@ -3090,14 +2920,12 @@
         "lodash._reinterpolate": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-          "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI=",
-          "dev": true
+          "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
         },
         "lodash.escape": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
           "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-          "dev": true,
           "requires": {
             "lodash._escapehtmlchar": "~2.4.1",
             "lodash._reunescapedhtml": "~2.4.1",
@@ -3108,7 +2936,6 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true,
           "requires": {
             "lodash._isnative": "~2.4.1",
             "lodash._shimkeys": "~2.4.1",
@@ -3119,7 +2946,6 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
           "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-          "dev": true,
           "requires": {
             "lodash._escapestringchar": "~2.4.1",
             "lodash._reinterpolate": "~2.4.1",
@@ -3134,16 +2960,15 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
           "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-          "dev": true,
           "requires": {
             "lodash._reinterpolate": "~2.4.1",
             "lodash.escape": "~2.4.1"
           }
         },
         "minimist": {
-          "version": "0.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784=",
+          "version": "0.2.4",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.2.4.tgz",
+          "integrity": "sha512-Pkrrm8NjyQ8yVt8Am9M+yUt74zE3iokhzbG1bFVNjLB92vwM71hf40RkEsryg98BujhVOncKm/C1xROxZ030LQ==",
           "dev": true
         },
         "strip-ansi": {
@@ -3324,6 +3149,23 @@
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
+        "lodash.template": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+          "integrity": "sha512-0B4Y53I0OgHUJkt+7RmlDFWKjVAI/YUpWNiL9GQz5ORDr4ttgfQGo+phBWKFLJbBdtOwgMuUkdOHOnPg45jKmQ==",
+          "dev": true,
+          "requires": {
+            "lodash._basecopy": "^3.0.0",
+            "lodash._basetostring": "^3.0.0",
+            "lodash._basevalues": "^3.0.0",
+            "lodash._isiterateecall": "^3.0.0",
+            "lodash._reinterpolate": "^3.0.0",
+            "lodash.escape": "^3.0.0",
+            "lodash.keys": "^3.0.0",
+            "lodash.restparam": "^3.0.0",
+            "lodash.templatesettings": "^3.0.0"
+          }
+        },
         "object-assign": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -3381,31 +3223,14 @@
         "glogg": "^1.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
-    },
-    "has-color": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
-      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-gulplog": {
       "version": "0.1.0",
@@ -3419,7 +3244,7 @@
     "has-hover": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
-      "integrity": "sha1-PZdDeusZnGK4rAisvcU9O8UsF/c=",
+      "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
       "requires": {
         "is-browser": "^2.0.1"
       }
@@ -3431,11 +3256,6 @@
       "requires": {
         "is-browser": "^2.0.1"
       }
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
     },
     "has-value": {
       "version": "1.0.0",
@@ -3487,17 +3307,22 @@
     "hsluv": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
-      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
+      "integrity": "sha512-08iL2VyCRbkQKBySkSh6m8zMUa3sADAxGVWs3Z1aPcUkTJeK0ETG4Fc27tEmQBGUAXZjIsXOZqBvacuVNSC/fQ=="
     },
     "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "image-size": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.7.5.tgz",
+      "integrity": "sha512-Hiyv+mXHfFEP7LzUL/llg9RwFxxY+o9N3JVLIeG5E7iFIFAalxvRU9UZthBdYDEVnzHMgjnKJPPpay5BWf1g9g=="
     },
     "incremental-convex-hull": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/incremental-convex-hull/-/incremental-convex-hull-1.0.1.tgz",
-      "integrity": "sha1-UUKMFMudmmFEv+abKFH7N3M0vh4=",
+      "integrity": "sha512-mKRJDXtzo1R9LxCuB1TdwZXHaPaIEldoGPsXy2jrJc/kufyqp8y/VAQQxThSxM2aroLoh6uObexPk1ASJ7FB7Q==",
       "requires": {
         "robust-orientation": "^1.1.2",
         "simplicial-complex": "^1.0.0"
@@ -3516,6 +3341,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3539,22 +3365,22 @@
       "dev": true
     },
     "interval-tree-1d": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.3.tgz",
-      "integrity": "sha1-j9veArayx9verWNry+2OCHENhcE=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interval-tree-1d/-/interval-tree-1d-1.0.4.tgz",
+      "integrity": "sha512-wY8QJH+6wNI0uh4pDQzMvl+478Qh7Rl4qLmqiluxALlNvl+I+o5x38Pw3/z7mDPTPS1dQalZJXsmbvxx5gclhQ==",
       "requires": {
-        "binary-search-bounds": "^1.0.0"
+        "binary-search-bounds": "^2.0.0"
       }
     },
     "invert-permutation": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-permutation/-/invert-permutation-1.0.0.tgz",
-      "integrity": "sha1-oKeAQurbNrwXVR54fv0UOa3VSTM="
+      "integrity": "sha512-8f473/KSrnvyBd7Khr4PC5wPkAOehwkGc+AH5Q7D+U/fE+cdDob2FJ3naXAs4mspR9JIaEwbDI3me8H0KlVzSQ=="
     },
     "iota-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
-      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA=="
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -3600,11 +3426,6 @@
         "builtin-modules": "^1.0.0"
       }
     },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
-    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -3613,11 +3434,6 @@
       "requires": {
         "kind-of": "^3.0.2"
       }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -3641,7 +3457,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -3653,10 +3470,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
+    },
+    "is-firefox": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
+      "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA=="
     },
     "is-glob": {
       "version": "3.1.0",
@@ -3670,12 +3491,12 @@
     "is-iexplorer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
-      "integrity": "sha1-HXK8ZtP+Iur2Fw3ajPEJQySM/HY="
+      "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg=="
     },
     "is-mobile": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.0.0.tgz",
-      "integrity": "sha512-k2+p7BBCzhqHMdYJwGUNNo+6zegGiMIVbM6bEPzxWXpQV6BUzV892UW0oDFgqxT6DygO7LdxRbwC0xmOhJdbew=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-2.2.2.tgz",
+      "integrity": "sha512-wW/SXnYJkTjs++tVK5b6kVITZpAZPtUrt9SF80vvxGiF/Oywal+COk1jlRkiVq15RFNEQKQY31TkV24/1T5cVg=="
     },
     "is-number": {
       "version": "3.0.0",
@@ -3689,12 +3510,12 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -3703,14 +3524,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.1"
-      }
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "requires": {
-        "has": "^1.0.1"
       }
     },
     "is-relative": {
@@ -3730,15 +3543,7 @@
     "is-svg-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
-      "integrity": "sha1-d6tZDBKz0gNI5cehPQBAyHeE3aA="
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
+      "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg=="
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -3783,45 +3588,16 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
       "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
     },
-    "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        }
-      }
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-    },
-    "jsonlint-lines-primitives": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/jsonlint-lines-primitives/-/jsonlint-lines-primitives-1.6.0.tgz",
-      "integrity": "sha1-u4n2DIubYS/ZE92qI2ZJuEDYZhE=",
-      "requires": {
-        "JSV": ">= 4.0.x",
-        "nomnom": ">= 1.5.x"
-      }
-    },
     "kdbush": {
-      "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/kdbush/-/kdbush-1.0.1.tgz",
-      "integrity": "sha1-PL0D6d6tnA9vZszblkUOXOzGQOA="
+      "version": "3.0.0",
+      "resolved": "http://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
     },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -3829,22 +3605,18 @@
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-    },
-    "left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
     },
     "lerp": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
-      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24="
+      "integrity": "sha512-70Rh4rCkJDvwWiTsyZ1HmJGvnyfFah4m6iTux29XmasRiZPDBpT9Cfa4ai73+uLZxnlKruUS62jj2lb11wURiA=="
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -3917,7 +3689,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
       "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-      "dev": true,
       "requires": {
         "lodash._htmlescapes": "~2.4.1"
       }
@@ -3925,8 +3696,7 @@
     "lodash._escapestringchar": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I=",
-      "dev": true
+      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -3937,8 +3707,7 @@
     "lodash._htmlescapes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs=",
-      "dev": true
+      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
     },
     "lodash._isiterateecall": {
       "version": "3.0.9",
@@ -3949,14 +3718,12 @@
     "lodash._isnative": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=",
-      "dev": true
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
     },
     "lodash._objecttypes": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=",
-      "dev": true
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
     },
     "lodash._reescape": {
       "version": "3.0.0",
@@ -3980,7 +3747,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
       "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-      "dev": true,
       "requires": {
         "lodash._htmlescapes": "~2.4.1",
         "lodash.keys": "~2.4.1"
@@ -3990,7 +3756,6 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true,
           "requires": {
             "lodash._isnative": "~2.4.1",
             "lodash._shimkeys": "~2.4.1",
@@ -4009,7 +3774,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.4.1"
       }
@@ -4018,7 +3782,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
       "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.4.1",
         "lodash.keys": "~2.4.1"
@@ -4028,7 +3791,6 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true,
           "requires": {
             "lodash._isnative": "~2.4.1",
             "lodash._shimkeys": "~2.4.1",
@@ -4062,7 +3824,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-      "dev": true,
       "requires": {
         "lodash._objecttypes": "~2.4.1"
       }
@@ -4084,23 +3845,6 @@
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
-    "lodash.template": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
-      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash._basetostring": "^3.0.0",
-        "lodash._basevalues": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0",
-        "lodash._reinterpolate": "^3.0.0",
-        "lodash.escape": "^3.0.0",
-        "lodash.keys": "^3.0.0",
-        "lodash.restparam": "^3.0.0",
-        "lodash.templatesettings": "^3.0.0"
-      }
-    },
     "lodash.templatesettings": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
@@ -4115,7 +3859,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
       "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-      "dev": true,
       "requires": {
         "lodash.keys": "~2.4.1"
       },
@@ -4124,7 +3867,6 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
           "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-          "dev": true,
           "requires": {
             "lodash._isnative": "~2.4.1",
             "lodash._shimkeys": "~2.4.1",
@@ -4136,7 +3878,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -4153,14 +3896,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
-    },
-    "magic-string": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.1.tgz",
-      "integrity": "sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==",
-      "requires": {
-        "sourcemap-codec": "^1.4.1"
-      }
     },
     "make-error": {
       "version": "1.3.5",
@@ -4203,7 +3938,7 @@
     "map-limit": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
-      "integrity": "sha1-63lhAxwPDo0AG/LVb6toXViCLzg=",
+      "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
       "requires": {
         "once": "~1.3.0"
       },
@@ -4211,7 +3946,7 @@
         "once": {
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
           "requires": {
             "wrappy": "1"
           }
@@ -4240,160 +3975,39 @@
       }
     },
     "mapbox-gl": {
-      "version": "0.44.1",
-      "resolved": "http://registry.npmjs.org/mapbox-gl/-/mapbox-gl-0.44.1.tgz",
-      "integrity": "sha512-K6GfXfvumPgiw3NSFGTPYU7VinhWLKFbRmNTx/mPWzxzazfKZsChuyZ9IEhZ6LuFEnV1qzquyg5kLUCledVzvg==",
+      "version": "1.10.1",
+      "resolved": "http://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.10.1.tgz",
+      "integrity": "sha512-0aHt+lFUpYfvh0kMIqXqNXqoYMuhuAsMlw87TbhWrw78Tx2zfuPI0Lx31/YPUgJ+Ire0tzQ4JnuBL7acDNXmMg==",
       "requires": {
-        "@mapbox/gl-matrix": "^0.0.1",
-        "@mapbox/mapbox-gl-supported": "^1.3.0",
+        "@mapbox/geojson-rewind": "^0.5.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
         "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/shelf-pack": "^3.1.0",
-        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
         "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.0",
-        "@mapbox/whoots-js": "^3.0.0",
-        "brfs": "^1.4.0",
-        "bubleify": "^0.7.0",
-        "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.3",
-        "geojson-rewind": "^0.3.0",
-        "geojson-vt": "^3.0.0",
-        "gray-matter": "^3.0.8",
-        "grid-index": "^1.0.0",
-        "jsonlint-lines-primitives": "~1.6.0",
-        "minimist": "0.0.8",
-        "package-json-versionify": "^1.0.2",
-        "pbf": "^3.0.5",
-        "quickselect": "^1.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "minimist": "^1.2.5",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
-        "shuffle-seed": "^1.1.6",
-        "sort-object": "^0.3.2",
-        "supercluster": "^2.3.0",
-        "through2": "^2.0.3",
-        "tinyqueue": "^1.1.0",
-        "unassertify": "^2.0.0",
-        "unflowify": "^1.0.0",
-        "vt-pbf": "^3.0.1",
-        "webworkify": "^1.5.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-        },
-        "buble": {
-          "version": "0.15.2",
-          "resolved": "https://registry.npmjs.org/buble/-/buble-0.15.2.tgz",
-          "integrity": "sha1-VH/EdIP45egXbYKqXrzLGDsC1hM=",
-          "requires": {
-            "acorn": "^3.3.0",
-            "acorn-jsx": "^3.0.1",
-            "acorn-object-spread": "^1.0.0",
-            "chalk": "^1.1.3",
-            "magic-string": "^0.14.0",
-            "minimist": "^1.2.0",
-            "os-homedir": "^1.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-            }
-          }
-        },
-        "bubleify": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/bubleify/-/bubleify-0.7.0.tgz",
-          "integrity": "sha1-0I6mQv/Qhf+HEciEP1cHLw1euPY=",
-          "requires": {
-            "buble": "^0.15.1",
-            "object-assign": "^4.0.1"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "magic-string": {
-          "version": "0.14.0",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.14.0.tgz",
-          "integrity": "sha1-VyJK7xcByu7Sc7F6OalW5ysXJGI=",
-          "requires": {
-            "vlq": "^0.2.1"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        },
-        "vlq": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-          "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
-        }
+        "supercluster": "^7.0.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
       }
     },
     "marching-simplex-table": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/marching-simplex-table/-/marching-simplex-table-1.0.0.tgz",
-      "integrity": "sha1-vBYlbg+Pm1WKqbKHL4gy2UM/Uuo=",
+      "integrity": "sha512-PexXXVF4f5Bux3vGCNlRRBqF/GyTerNo77PbBz8g/MFFXv212b48IGVglj/VfaYBRY6vlFQffa9dFbCCN0+7LA==",
       "requires": {
         "convex-hull": "^1.0.3"
       }
@@ -4401,7 +4015,7 @@
     "mat4-decompose": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-decompose/-/mat4-decompose-1.0.4.tgz",
-      "integrity": "sha1-ZetP451wh496RE60Yk1S9+frL68=",
+      "integrity": "sha512-M3x6GXrzRTt5Ok4/bcHFc869Pe8F3uWaSp3xkUpi+uaTRulPXIZ1GWD13Z3A8WK2bxTrcvX21mjp05gUy/Dwbw==",
       "requires": {
         "gl-mat4": "^1.0.1",
         "gl-vec3": "^1.0.2"
@@ -4410,7 +4024,7 @@
     "mat4-interpolate": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-interpolate/-/mat4-interpolate-1.0.4.tgz",
-      "integrity": "sha1-Vf/p6zw1KV4sDVqfdyXZBoqJ/3Q=",
+      "integrity": "sha512-+ulnoc6GUHq8eGZGbLyhQU61tx2oeNAFilV/xzCCzLV+F3nDk8jqERUqRmx8eNMMMvrdvoRSw0JXmnisfVPY9A==",
       "requires": {
         "gl-mat4": "^1.0.1",
         "gl-vec3": "^1.0.2",
@@ -4422,7 +4036,7 @@
     "mat4-recompose": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mat4-recompose/-/mat4-recompose-1.0.4.tgz",
-      "integrity": "sha1-OVPCMP8kc9x3LuAUpSySXPgbDk0=",
+      "integrity": "sha512-s1P2Yl4LQxq8dN0CgJE+mCO8y3IX/SmauSZ+H0zJsE1UKlgJ9loInfPC/OUxn2MzUW9bfBZf0Wcc2QKA3/e6FQ==",
       "requires": {
         "gl-mat4": "^1.0.1"
       }
@@ -4430,14 +4044,14 @@
     "math-log2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
-      "integrity": "sha1-+4lBvl9evol55xjmJzsXjlhpRWU="
+      "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA=="
     },
     "matrix-camera-controller": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.3.tgz",
-      "integrity": "sha1-NeUmDMHNVQliunmfLY1OlLGjk3A=",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/matrix-camera-controller/-/matrix-camera-controller-2.1.4.tgz",
+      "integrity": "sha512-zsPGPONclrKSImNpqqKDTcqFpWLAIwMXEJtCde4IFPOw1dA9udzFg4HOFytOTosOFanchrx7+Hqq6glLATIxBA==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
+        "binary-search-bounds": "^2.0.0",
         "gl-mat4": "^1.1.2",
         "gl-vec3": "^1.0.3",
         "mat4-interpolate": "^1.0.3"
@@ -4459,21 +4073,6 @@
         "read-pkg-up": "^1.0.1",
         "redent": "^1.0.0",
         "trim-newlines": "^1.0.0"
-      }
-    },
-    "merge-source-map": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
-      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
-      "requires": {
-        "source-map": "^0.5.6"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
       }
     },
     "micromatch": {
@@ -4528,14 +4127,15 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "version": "1.2.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -4559,26 +4159,18 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.6",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.6"
       }
     },
     "monotone-convex-hull-2d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/monotone-convex-hull-2d/-/monotone-convex-hull-2d-1.0.1.tgz",
-      "integrity": "sha1-R/Xa6t88Sv03dkuqGqh4ekDu4Iw=",
+      "integrity": "sha512-ixQ3qdXTVHvR7eAoOjKY8kGxl9YjOFtzi7qOjwmFFPfBqZHVOjUFOBy/Dk9dusamRSPJe9ggyfSypRbs0Bl8BA==",
       "requires": {
         "robust-orientation": "^1.1.3"
       }
@@ -4586,7 +4178,7 @@
     "mouse-change": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
-      "integrity": "sha1-wrd+W/o0pDzhRFyBV6Tk3JiVwU8=",
+      "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
       "requires": {
         "mouse-event": "^1.0.0"
       }
@@ -4594,17 +4186,17 @@
     "mouse-event": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
-      "integrity": "sha1-s3ie23EJmX1aky0dAdqhVDpQFzI="
+      "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw=="
     },
     "mouse-event-offset": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
-      "integrity": "sha1-39hqbiSMa6jK1TuQXVA3ogY+mYQ="
+      "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w=="
     },
     "mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
-      "integrity": "sha1-bSkDseqPtI5h8bU7kDZ3PwQs21w=",
+      "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
       "requires": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -4614,7 +4206,7 @@
         "signum": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
-          "integrity": "sha1-dKfSvyogtA66FqkrFSEk8dVZ+nc="
+          "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw=="
         }
       }
     },
@@ -4623,24 +4215,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "multi-stage-sourcemap": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/multi-stage-sourcemap/-/multi-stage-sourcemap-0.2.1.tgz",
-      "integrity": "sha1-sJ/IWG6qF/gdV1xK0C4Pej9rEQU=",
-      "requires": {
-        "source-map": "^0.1.34"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
     },
     "multipipe": {
       "version": "0.1.2",
@@ -4654,7 +4228,7 @@
     "mumath": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
-      "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
+      "integrity": "sha512-VAFIOG6rsxoc7q/IaY3jdjmrsuX9f15KlRLYTHmixASBZkZEKC1IFqE2BC5CdhXmK6WLM1Re33z//AGmeRI6FA==",
       "requires": {
         "almost-equal": "^1.1.0"
       }
@@ -4662,7 +4236,7 @@
     "murmurhash-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
-      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4717,9 +4291,9 @@
       "dev": true
     },
     "ndarray": {
-      "version": "1.0.18",
-      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
-      "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
       "requires": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
@@ -4728,46 +4302,29 @@
     "ndarray-extract-contour": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ndarray-extract-contour/-/ndarray-extract-contour-1.0.1.tgz",
-      "integrity": "sha1-Cu4ROjozsia5DEiIz4d79HUTBeQ=",
+      "integrity": "sha512-iDngNoFRqrqbXGLP8BzyGrybw/Jnkkn7jphzc3ZFfO7dfmpL1Ph74/6xCi3xSvJFyVW90XpMnd766jTaRPsTCg==",
       "requires": {
         "typedarray-pool": "^1.0.0"
       }
     },
-    "ndarray-fill": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ndarray-fill/-/ndarray-fill-1.0.2.tgz",
-      "integrity": "sha1-owpg9xiODJWC/N1YiWrNy1IqHtY=",
-      "requires": {
-        "cwise": "^1.0.10"
-      }
-    },
     "ndarray-gradient": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.0.tgz",
-      "integrity": "sha1-t0kaUVxqZJ8ZpiMk//byf8jCU5M=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ndarray-gradient/-/ndarray-gradient-1.0.1.tgz",
+      "integrity": "sha512-+xONVi7xxTCGL6KOb11Yyoe0tPNqAUKF39CvFoRjL5pdOmPd2G2pckK9lD5bpLF3q45LLnYNyiUSJSdNmQ2MTg==",
       "requires": {
         "cwise-compiler": "^1.0.0",
         "dup": "^1.0.0"
       }
     },
-    "ndarray-homography": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ndarray-homography/-/ndarray-homography-1.0.0.tgz",
-      "integrity": "sha1-w1UW6oa8KGK06ASiNqJwcwn+KWs=",
-      "requires": {
-        "gl-matrix-invert": "^1.0.0",
-        "ndarray-warp": "^1.0.0"
-      }
-    },
     "ndarray-linear-interpolate": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ndarray-linear-interpolate/-/ndarray-linear-interpolate-1.0.0.tgz",
-      "integrity": "sha1-eLySuFuavBW25n7mWCj54hN65ys="
+      "integrity": "sha512-UN0f4+6XWsQzJ2pP5gVp+kKn5tJed6mA3K/L50uO619+7LKrjcSNdcerhpqxYaSkbxNJuEN76N05yBBJySnZDw=="
     },
     "ndarray-ops": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
-      "integrity": "sha1-WeiNLDKn7ryxvGkPrhQVeVV6YU4=",
+      "integrity": "sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==",
       "requires": {
         "cwise-compiler": "^1.0.0"
       }
@@ -4775,7 +4332,7 @@
     "ndarray-pack": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
-      "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
+      "integrity": "sha512-51cECUJMT0rUZNQa09EoKsnFeDL4x2dHRT0VR5U2H5ZgEcm95ZDWcMA5JShroXjHOejmAD/fg8+H+OvUnVXz2g==",
       "requires": {
         "cwise-compiler": "^1.1.2",
         "ndarray": "^1.0.13"
@@ -4784,7 +4341,7 @@
     "ndarray-scratch": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ndarray-scratch/-/ndarray-scratch-1.2.0.tgz",
-      "integrity": "sha1-YwRjbWLrqT20cnrBPGkzQdulDgE=",
+      "integrity": "sha512-a4pASwB1jQyJcKLYrwrladVfDZDUGc78qLJZbHyb1Q4rhte0URhzc6ALQpBcauwgov0sXLwZz3vYH5jKAhSMIg==",
       "requires": {
         "ndarray": "^1.0.14",
         "ndarray-ops": "^1.2.1",
@@ -4794,62 +4351,22 @@
     "ndarray-sort": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ndarray-sort/-/ndarray-sort-1.0.1.tgz",
-      "integrity": "sha1-/qBbTLg0x/TgIWo1TzynUTAN/Wo=",
+      "integrity": "sha512-Gpyis5NvEPOQVadDOG+Dx8bhYCkaxn5IlA4Ig/jBJIlnW1caDiPneQLzT/+AIMeHEmqlGZfdqO/I1TXJS2neAw==",
       "requires": {
         "typedarray-pool": "^1.0.0"
       }
     },
-    "ndarray-warp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ndarray-warp/-/ndarray-warp-1.0.1.tgz",
-      "integrity": "sha1-qKElqqu6C+v5O9bKg+ar1oIqNOA=",
-      "requires": {
-        "cwise": "^1.0.4",
-        "ndarray-linear-interpolate": "^1.0.0"
-      }
-    },
     "next-tick": {
-      "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nextafter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/nextafter/-/nextafter-1.0.0.tgz",
-      "integrity": "sha1-t9d7U1MQ4+CX5gJauwqQNHfsGjo=",
+      "integrity": "sha512-7PO+A89Tll2rSEfyrjtqO0MaI37+nnxBdnQcPypfbEYYuGaJxWGCqaOwQX4a3GHNTS08l1kazuiLEWZniZjMUQ==",
       "requires": {
         "double-bits": "^1.1.0"
-      }
-    },
-    "nomnom": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-      "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-      "requires": {
-        "chalk": "~0.4.0",
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
-        },
-        "chalk": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-          "requires": {
-            "ansi-styles": "~1.0.0",
-            "has-color": "~0.1.0",
-            "strip-ansi": "~0.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "0.1.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
-          "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
-        }
       }
     },
     "normalize-package-data": {
@@ -4867,23 +4384,30 @@
     "normalize-svg-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
-      "integrity": "sha1-RWNg5g7Odfvve11+FgSA5//Rb+U="
+      "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA=="
     },
     "normals": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/normals/-/normals-1.1.0.tgz",
-      "integrity": "sha1-MltZXtNK/kZ6bFWhT9kIV4f/WcA="
+      "integrity": "sha512-XWeliW48BLvbVJ+cjQAOE+tA0m1M7Yi1iTPphAS9tBmW1A/c/cOVnEUecPCCMH5lEAihAcG6IRle56ls9k3xug=="
+    },
+    "number-is-integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
+      "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
+      "requires": {
+        "is-finite": "^1.0.1"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "numeric": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
+      "integrity": "sha512-avBiDAP8siMa7AfJgYyuxw1oyII4z2sswS23+O+ZfV28KrtNzy0wxUFwi4f3RyM4eeeXNs1CThxR7pb5QQcMiw=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -4911,16 +4435,6 @@
           }
         }
       }
-    },
-    "object-inspect": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
-      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
-    },
-    "object-keys": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -4970,28 +4484,23 @@
         "wrappy": "1"
       }
     },
-    "optical-properties": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/optical-properties/-/optical-properties-1.0.0.tgz",
-      "integrity": "sha512-XnBQYbIIzDVr7U3L7d3xyAEqp1W+HTkqmw/G4L/Ae/+dq57bT1jqW2uDwV0wCUzO8gsTDIZhGQsGrMb17VSkEA=="
-    },
     "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "requires": {
         "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
+        "fast-levenshtein": "~2.0.6",
         "levn": "~0.3.0",
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "word-wrap": "~1.2.3"
       }
     },
     "orbit-camera-controller": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/orbit-camera-controller/-/orbit-camera-controller-4.0.0.tgz",
-      "integrity": "sha1-bis28OeHhmPDMPUNqbfOaGwncAU=",
+      "integrity": "sha512-/XTmpr6FUT6MuKPBGN2nv9cS8jhhVs8do71VagBQS5p4rxM04MhqSnI/Uu+gVNN5s6KPcS73o1dHzjuDThEJUA==",
       "requires": {
         "filtered-vector": "^1.2.1",
         "gl-mat4": "^1.0.3"
@@ -5037,23 +4546,21 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
-    "package-json-versionify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/package-json-versionify/-/package-json-versionify-1.0.4.tgz",
-      "integrity": "sha1-WGBYepRIc6a35tJujlH/siMVvxc=",
-      "requires": {
-        "browserify-package-json": "^1.0.0"
-      }
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "pad-left": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
-      "integrity": "sha1-GeVzXqmDlaJs7carkm6tEPMQDUw=",
+      "integrity": "sha512-saxSV1EYAytuZDtQYEwi0DPzooG6aN18xyHrnJtzwjVwmMauzkEecd7hynVJGolNGk1Pl9tltmZqfze4TZTCxg==",
       "requires": {
         "repeat-string": "^1.3.0"
       }
+    },
+    "parenthesis": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
+      "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw=="
     },
     "parse-filepath": {
       "version": "1.0.2",
@@ -5092,12 +4599,12 @@
     "parse-svg-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
-      "integrity": "sha1-en7A0esG+lMlx9PgCbhZoJtdSes="
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
     },
     "parse-unit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
-      "integrity": "sha1-fhu21b7zh0wo45JSaiVBFwKR7s8="
+      "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -5117,7 +4624,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
@@ -5151,23 +4659,23 @@
       }
     },
     "pbf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.1.0.tgz",
-      "integrity": "sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
+      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
       "requires": {
-        "ieee754": "^1.1.6",
-        "resolve-protobuf-schema": "^2.0.0"
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "permutation-parity": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/permutation-parity/-/permutation-parity-1.0.0.tgz",
-      "integrity": "sha1-AXTVH8pwSxG5pLFSsj1Tf9xrXvQ=",
+      "integrity": "sha512-mRaEvnnWolbZuErWD08StRUZP9YOWG3cURP5nYpRg1D2PENzPXCUrPv8/bOk0tfln0hISLZjOdOcQCbsVpL2nQ==",
       "requires": {
         "typedarray-pool": "^1.0.0"
       }
@@ -5175,7 +4683,7 @@
     "permutation-rank": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/permutation-rank/-/permutation-rank-1.0.0.tgz",
-      "integrity": "sha1-n9mLvOzwj79ZlLXq3JSmLmeUg7U=",
+      "integrity": "sha512-kmXwlQcd4JlV8g61jz0xDyroFNlJ/mP+KbSBllMuQD7FvaQInRnnAStElcppkUXd8qVFLvemy6msUmBn7sDzHg==",
       "requires": {
         "invert-permutation": "^1.0.0",
         "typedarray-pool": "^1.0.0"
@@ -5184,7 +4692,7 @@
     "pick-by-alias": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
-      "integrity": "sha1-X3yysfIabh6ISgyHhVqko3NhEHs="
+      "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw=="
     },
     "pify": {
       "version": "2.3.0",
@@ -5210,20 +4718,20 @@
     "planar-dual": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/planar-dual/-/planar-dual-1.0.2.tgz",
-      "integrity": "sha1-tqQjVSOxsMt55fkm+OozXdmC1WM=",
+      "integrity": "sha512-jfQCbX1kXu53+enC+BPQlfoZI1u5m8IUhFVtFG+9tUj84wnuaYNheR69avYWCNXWnUCkwUajmYMqX9M2Ruh4ug==",
       "requires": {
         "compare-angle": "^1.0.0",
         "dup": "^1.0.0"
       }
     },
     "planar-graph-to-polyline": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.5.tgz",
-      "integrity": "sha1-iCuGBRmbqIv9RkyVUzA1VsUrmIo=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/planar-graph-to-polyline/-/planar-graph-to-polyline-1.0.6.tgz",
+      "integrity": "sha512-h8a9kdAjo7mRhC0X6HZ42xzFp7vKDZA+Hygyhsq/08Qi4vVAQYJaLLYLvKUUzRbVKvdYqq0reXHyV0EygyEBHA==",
       "requires": {
         "edges-to-adjacency-list": "^1.0.0",
         "planar-dual": "^1.0.0",
-        "point-in-big-polygon": "^2.0.0",
+        "point-in-big-polygon": "^2.0.1",
         "robust-orientation": "^1.0.1",
         "robust-sum": "^1.0.0",
         "two-product": "^1.0.0",
@@ -5231,100 +4739,86 @@
       }
     },
     "plotly.js": {
-      "version": "1.36.1",
-      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.36.1.tgz",
-      "integrity": "sha512-wD56B50N2JHDi5UqoW8s10+SABF0O6IQLABYCJx481ryWeFo4HBhjoiNtmEoY3VKUd97G/okX2/wtNvfcnbW6A==",
+      "version": "1.58.5",
+      "resolved": "https://registry.npmjs.org/plotly.js/-/plotly.js-1.58.5.tgz",
+      "integrity": "sha512-ChTlnFXB4tB0CzcG1mqgUKYnrJsZ8REDGox8BHAa/ltsd48MOAhOmFgjyDxwsXyjjgwOI296GeYDft8g4ftLHQ==",
       "requires": {
-        "3d-view": "^2.0.0",
-        "@plotly/d3-sankey": "^0.5.0",
+        "@plotly/d3-sankey": "0.7.2",
+        "@plotly/d3-sankey-circular": "0.33.1",
+        "@plotly/point-cluster": "^3.1.9",
+        "@turf/area": "^6.0.1",
+        "@turf/bbox": "^6.0.1",
+        "@turf/centroid": "^6.0.2",
         "alpha-shape": "^1.0.0",
-        "array-range": "^1.0.1",
-        "bubleify": "^1.0.0",
         "canvas-fit": "^1.5.0",
-        "color-normalize": "^1.0.3",
-        "color-rgba": "^2.0.0",
+        "color-alpha": "1.0.4",
+        "color-normalize": "1.5.0",
+        "color-parse": "1.3.8",
+        "color-rgba": "2.1.1",
         "convex-hull": "^1.0.3",
         "country-regex": "^1.1.0",
-        "d3": "^3.5.12",
-        "d3-force": "^1.0.6",
+        "d3": "^3.5.17",
+        "d3-force": "^1.2.1",
+        "d3-hierarchy": "^1.1.9",
+        "d3-interpolate": "^1.4.0",
+        "d3-time-format": "^2.2.3",
         "delaunay-triangulate": "^1.1.6",
-        "es6-promise": "^3.0.2",
-        "fast-isnumeric": "^1.1.1",
-        "font-atlas-sdf": "^1.3.3",
-        "gl-contour2d": "^1.1.4",
-        "gl-error3d": "^1.0.7",
-        "gl-heatmap2d": "^1.0.4",
-        "gl-line3d": "^1.1.2",
-        "gl-mat4": "^1.1.2",
-        "gl-mesh3d": "^2.0.0",
-        "gl-plot2d": "^1.3.1",
-        "gl-plot3d": "^1.5.5",
-        "gl-pointcloud2d": "^1.0.1",
-        "gl-scatter3d": "^1.0.11",
-        "gl-select-box": "^1.0.2",
-        "gl-spikes2d": "^1.0.1",
-        "gl-surface3d": "^1.3.4",
-        "glslify": "^6.1.1",
+        "es6-promise": "^4.2.8",
+        "fast-isnumeric": "^1.1.4",
+        "gl-cone3d": "^1.5.2",
+        "gl-contour2d": "^1.1.7",
+        "gl-error3d": "^1.0.16",
+        "gl-heatmap2d": "^1.1.0",
+        "gl-line3d": "1.2.1",
+        "gl-mat4": "^1.2.0",
+        "gl-mesh3d": "^2.3.1",
+        "gl-plot2d": "^1.4.5",
+        "gl-plot3d": "^2.4.7",
+        "gl-pointcloud2d": "^1.0.3",
+        "gl-scatter3d": "^1.2.3",
+        "gl-select-box": "^1.0.4",
+        "gl-spikes2d": "^1.0.2",
+        "gl-streamtube3d": "^1.4.1",
+        "gl-surface3d": "^1.6.0",
+        "gl-text": "^1.1.8",
+        "glslify": "^7.1.1",
         "has-hover": "^1.0.1",
         "has-passive-events": "^1.0.0",
-        "mapbox-gl": "0.44.1",
+        "image-size": "^0.7.5",
+        "is-mobile": "^2.2.2",
+        "mapbox-gl": "1.10.1",
         "matrix-camera-controller": "^2.1.3",
         "mouse-change": "^1.4.0",
         "mouse-event-offset": "^3.0.2",
-        "mouse-wheel": "^1.0.2",
-        "ndarray": "^1.0.18",
-        "ndarray-fill": "^1.0.2",
-        "ndarray-homography": "^1.0.0",
-        "ndarray-ops": "^1.2.2",
-        "point-cluster": "^3.1.2",
+        "mouse-wheel": "^1.2.0",
+        "ndarray": "^1.0.19",
+        "ndarray-linear-interpolate": "^1.0.0",
+        "parse-svg-path": "^0.1.2",
         "polybooljs": "^1.2.0",
-        "regl": "^1.3.1",
-        "regl-error2d": "^2.0.3",
-        "regl-line2d": "^3.0.3",
-        "regl-scatter2d": "^3.0.1",
-        "regl-splom": "^1.0.0",
+        "regl": "^1.6.1",
+        "regl-error2d": "^2.0.11",
+        "regl-line2d": "^3.0.18",
+        "regl-scatter2d": "^3.2.1",
+        "regl-splom": "^1.0.12",
         "right-now": "^1.0.0",
         "robust-orientation": "^1.1.3",
-        "sane-topojson": "^2.0.0",
+        "sane-topojson": "^4.0.0",
         "strongly-connected-components": "^1.0.1",
         "superscript-text": "^1.0.0",
-        "svg-path-sdf": "^1.1.1",
-        "tinycolor2": "^1.3.0",
-        "topojson-client": "^2.1.0",
+        "svg-path-sdf": "^1.1.3",
+        "tinycolor2": "^1.4.2",
+        "to-px": "1.0.1",
+        "topojson-client": "^3.1.0",
         "webgl-context": "^2.2.0",
         "world-calendars": "^1.0.3"
       }
     },
-    "point-cluster": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-3.1.4.tgz",
-      "integrity": "sha512-jVjzC1vYoZlvcLWi170i41he5LhJTncOgFPaZx1uoqNn+8q+24xjLS9yG68XfN6/U1F52kliD6a3oXjJduerTQ==",
-      "requires": {
-        "array-bounds": "^1.0.1",
-        "array-normalize": "^1.1.3",
-        "binary-search-bounds": "^2.0.4",
-        "bubleify": "^1.1.0",
-        "clamp": "^1.0.1",
-        "dtype": "^2.0.0",
-        "flatten-vertex-data": "^1.0.0",
-        "is-obj": "^1.0.1",
-        "math-log2": "^1.0.1",
-        "parse-rect": "^1.2.0"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        }
-      }
-    },
     "point-in-big-polygon": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.0.tgz",
-      "integrity": "sha1-ObYT6mzxfWtD4Yj3fzTETGszulU=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/point-in-big-polygon/-/point-in-big-polygon-2.0.1.tgz",
+      "integrity": "sha512-DtrN8pa2VfMlvmWlCcypTFeBE4+OYz1ojDNJLKCWa4doiVAD6PRBbxFYAT71tsp5oKaRXT5sxEiHCAQKb1zr2Q==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
+        "binary-search-bounds": "^2.0.0",
         "interval-tree-1d": "^1.0.1",
         "robust-orientation": "^1.1.3",
         "slab-decomposition": "^1.0.1"
@@ -5333,12 +4827,12 @@
     "polybooljs": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.0.tgz",
-      "integrity": "sha1-tDkMLgedTCYtOyUExiiNlbp6R1g="
+      "integrity": "sha512-mKjR5nolISvF+q2BtC1fi/llpxBPTQ3wLWN8+ldzdw2Hocpc8C72ZqnamCM4Z6z+68GVVjkeM01WJegQmZ8MEQ=="
     },
     "polytope-closest-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/polytope-closest-point/-/polytope-closest-point-1.0.0.tgz",
-      "integrity": "sha1-5uV/QIGrXox3i4Ee8G4sSK4zjD8=",
+      "integrity": "sha512-rvmt1e2ci9AUyWeHg+jsNuhGC4eBtxX4WjD9uDdvQzv2I1CVJSgbblJTslNXpGUu4KZSsUtSzvIdHKRKfRF3kw==",
       "requires": {
         "numeric": "^1.2.6"
       }
@@ -5354,10 +4848,15 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w=="
     },
     "pretty-hrtime": {
       "version": "1.0.3",
@@ -5371,60 +4870,22 @@
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "protocol-buffers-schema": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
-      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "quat-slerp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/quat-slerp/-/quat-slerp-1.0.1.tgz",
-      "integrity": "sha1-K6oVzjprvcMkHZcusXKDE57Wnyk=",
+      "integrity": "sha512-OTozCDeP5sW7cloGR+aIycctZasBhblk1xdsSGP1Iz5pEwDqyChloTmc96xsDfusFD7GRxwDDu+tpJX0Wa1kJw==",
       "requires": {
         "gl-quat": "^1.0.0"
       }
     },
     "quickselect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-1.1.1.tgz",
-      "integrity": "sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ=="
-    },
-    "quote-stream": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-0.0.0.tgz",
-      "integrity": "sha1-zeKelMQJsW4Z3HCYuJtmWPlyHTs=",
-      "requires": {
-        "minimist": "0.0.8",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "raf": {
       "version": "3.4.1",
@@ -5437,7 +4898,7 @@
     "rat-vec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/rat-vec/-/rat-vec-1.1.1.tgz",
-      "integrity": "sha1-Dd4rZrezS7G80qI4BerIBth/0X8=",
+      "integrity": "sha512-FbxGwkQxmw4Jx41LR7yMOR+g8M9TWCEmf/SUBQVLuK2eh0nThnffF7IUualr3XE2x5F8AdLiCVeSGwXd4snfgg==",
       "requires": {
         "big-rat": "^1.0.3"
       }
@@ -5493,42 +4954,14 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "redeyed": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
-      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
-      "requires": {
-        "esprima": "~1.0.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-        }
-      }
-    },
     "reduce-simplicial-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reduce-simplicial-complex/-/reduce-simplicial-complex-1.0.0.tgz",
-      "integrity": "sha1-dNaWovg196bc2SBl/YxRgfLt+Lw=",
+      "integrity": "sha512-t+nT7sHDtcxBx8TbglqfLsLKoFiSn9hp6GFojJEThHBAFv72wQeq/uRiPYZa4Xb8FR1Ye1foRcBV3Ki6bgm+pQ==",
       "requires": {
         "cell-orientation": "^1.0.1",
         "compare-cell": "^1.0.0",
         "compare-oriented-cell": "^1.0.1"
-      }
-    },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
-    },
-    "regenerate-unicode-properties": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
-      "requires": {
-        "regenerate": "^1.4.0"
       }
     },
     "regex-not": {
@@ -5562,129 +4995,79 @@
         }
       }
     },
-    "regexpu-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.2.0.tgz",
-      "integrity": "sha512-Z835VSnJJ46CNBttalHD/dB+Sj2ezmY6Xp38npwU87peK6mqOzOpV8eYktdkLTEkzzD+JsTcxd84ozd8I14+rw==",
-      "requires": {
-        "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
-        "regjsgen": "^0.4.0",
-        "regjsparser": "^0.3.0",
-        "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
-      }
-    },
-    "regjsgen": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.4.0.tgz",
-      "integrity": "sha512-X51Lte1gCYUdlwhF28+2YMO0U6WeN0GLpgpA7LK7mbdDnkQYiwvEpmpe0F/cv5L14EbxgrdayAG3JETBv0dbXA=="
-    },
-    "regjsparser": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.3.0.tgz",
-      "integrity": "sha512-zza72oZBBHzt64G7DxdqrOo/30bhHkwMUoT0WqfGu98XLd7N+1tsy5MJ96Bk4MD0y74n629RhmrGW6XlnLLwCA==",
-      "requires": {
-        "jsesc": "~0.5.0"
-      }
-    },
     "regl": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/regl/-/regl-1.3.9.tgz",
-      "integrity": "sha512-CungQSUBsZNYZJWJlb2sPe4iwBjmxrgl1Yxt91HN3VuuEL7lJ5k03O3T1xEXVOCMN1q8wncddwJsxozuyzzmrA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/regl/-/regl-1.7.0.tgz",
+      "integrity": "sha512-bEAtp/qrtKucxXSJkD4ebopFZYP0q1+3Vb2WECWv/T8yQEgKxDxJ7ztO285tAMaYZVR6mM1GgI6CCn8FROtL1w=="
     },
     "regl-error2d": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.5.tgz",
-      "integrity": "sha512-hBxGSY0F9S3+JsobYiQBKdZ+0oWNpM6k8zeRxVDyv5rbZ2HNclVInrT82em+JPZ+GEh0OLmZdlS4BbPIuYAk2w==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
+      "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
       "requires": {
         "array-bounds": "^1.0.1",
-        "bubleify": "^1.0.0",
-        "color-normalize": "^1.0.3",
-        "flatten-vertex-data": "^1.0.0",
+        "color-normalize": "^1.5.0",
+        "flatten-vertex-data": "^1.0.2",
         "object-assign": "^4.1.1",
-        "pick-by-alias": "^1.1.1",
-        "to-float32": "^1.0.0",
-        "update-diff": "^1.0.2"
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
+        "update-diff": "^1.1.0"
       }
     },
     "regl-line2d": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.0.12.tgz",
-      "integrity": "sha512-6KV6ZbVWeoMZDqkVdqbWpvzrQR1BFOOUHMoyi1HDkZ3TXuS88s1/vQghTJjaLDRBVV5krZfIMpBrePY7OMxDIQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.2.tgz",
+      "integrity": "sha512-nmT7WWS/WxmXAQMkgaMKWXaVmwJ65KCrjbqHGOUjjqQi6shfT96YbBOvelXwO9hG7/hjvbzjtQ2UO0L3e7YaXQ==",
       "requires": {
-        "array-bounds": "^1.0.0",
-        "array-normalize": "^1.1.3",
-        "bubleify": "^1.0.0",
-        "color-normalize": "^1.0.0",
-        "earcut": "^2.1.1",
-        "es6-weak-map": "^2.0.2",
-        "flatten-vertex-data": "^1.0.0",
-        "glslify": "^6.3.1",
+        "array-bounds": "^1.0.1",
+        "array-find-index": "^1.0.2",
+        "array-normalize": "^1.1.4",
+        "color-normalize": "^1.5.0",
+        "earcut": "^2.1.5",
+        "es6-weak-map": "^2.0.3",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
         "object-assign": "^4.1.1",
         "parse-rect": "^1.2.0",
-        "pick-by-alias": "^1.1.0",
-        "to-float32": "^1.0.0"
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0"
       }
     },
     "regl-scatter2d": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.0.6.tgz",
-      "integrity": "sha512-l2/OcCRKTxsCtrGtb2TKUKYnDHzI07qOm2eK2kiRYKyDwiWiGyiLC6p3SlOxDoqhQ/8gbIue9BABPXuCJ0lpRQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.2.9.tgz",
+      "integrity": "sha512-PNrXs+xaCClKpiB2b3HZ2j3qXQXhC5kcTh/Nfgx9rLO0EpEhab0BSQDqAsbdbpdf+pSHSJvbgitB7ulbGeQ+Fg==",
       "requires": {
+        "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
         "array-rearrange": "^2.2.2",
-        "bubleify": "^1.0.0",
         "clamp": "^1.0.1",
         "color-id": "^1.1.0",
-        "color-normalize": "^1.0.3",
-        "flatten-vertex-data": "^1.0.0",
-        "glslify": "^6.1.1",
+        "color-normalize": "^1.5.0",
+        "color-rgba": "^2.1.1",
+        "flatten-vertex-data": "^1.0.2",
+        "glslify": "^7.0.0",
         "is-iexplorer": "^1.0.0",
         "object-assign": "^4.1.1",
-        "parse-rect": "^1.1.0",
-        "pick-by-alias": "^1.0.0",
-        "point-cluster": "^3.1.2",
-        "to-float32": "^1.0.0",
+        "parse-rect": "^1.2.0",
+        "pick-by-alias": "^1.2.0",
+        "to-float32": "^1.1.0",
         "update-diff": "^1.1.0"
       }
     },
     "regl-splom": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.4.tgz",
-      "integrity": "sha512-+iq/RJAJdHCp48wPbEGQ5qw29OXFVF/m7CzcuLZxwptjdkB/FHGKiMuyqclOSNQcEKFxQTvRRJMJJ6brd8VvrA==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
+      "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
       "requires": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
-        "bubleify": "^1.1.0",
-        "color-alpha": "^1.0.2",
-        "defined": "^1.0.0",
+        "color-alpha": "^1.0.4",
         "flatten-vertex-data": "^1.0.2",
-        "left-pad": "^1.2.0",
         "parse-rect": "^1.2.0",
         "pick-by-alias": "^1.2.0",
-        "point-cluster": "^1.0.2",
-        "raf": "^3.4.0",
-        "regl-scatter2d": "^3.0.6"
-      },
-      "dependencies": {
-        "binary-search-bounds": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.4.tgz",
-          "integrity": "sha512-2hg5kgdKql5ClF2ErBcSx0U5bnl5hgS4v7wMnLFodyR47yMtj2w+UAZB+0CiqyHct2q543i7Bi4/aMIegorCCg=="
-        },
-        "point-cluster": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/point-cluster/-/point-cluster-1.0.2.tgz",
-          "integrity": "sha512-pau5Py38SKgEJZ8pvD/bfXrz2TmQy6BEtMFZZSpjsQ2EmAe4CRO+HLhHw1gmgHVFaY/9KqhrfSeUPIsBOw8tDA==",
-          "requires": {
-            "array-bounds": "^1.0.1",
-            "array-normalize": "^1.1.3",
-            "binary-search-bounds": "^2.0.4",
-            "clamp": "^1.0.1",
-            "parse-rect": "^1.1.1"
-          }
-        }
+        "raf": "^3.4.1",
+        "regl-scatter2d": "^3.2.3"
       }
     },
     "remove-trailing-separator": {
@@ -5751,14 +5134,6 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "resumer": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "requires": {
-        "through": "~2.3.4"
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -5769,6 +5144,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
       "requires": {
         "align-text": "^0.1.1"
       }
@@ -5776,7 +5152,7 @@
     "right-now": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
-      "integrity": "sha1-bolgne69fc2vja7Mmuo5z1haCRg="
+      "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg=="
     },
     "rimraf": {
       "version": "2.6.1",
@@ -5790,12 +5166,12 @@
     "robust-compress": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-compress/-/robust-compress-1.0.0.tgz",
-      "integrity": "sha1-TPYsSzGNgwhRYBK7jBF1Lzkymxs="
+      "integrity": "sha512-E8btSpQ6zZr7LvRLrLvb+N5rwQ0etUbsXFKv5NQj6TVK6RYT00Qg9iVFvIWR+GxXUvpes7FDN0WfXa3l7wtGOw=="
     },
     "robust-determinant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/robust-determinant/-/robust-determinant-1.1.0.tgz",
-      "integrity": "sha1-jsrnm3nKqz509t6+IjflORon6cc=",
+      "integrity": "sha512-xva9bx/vyAv3pVYL2++vlnvM9q7oQOeCS5iscmlWtmaXHEgI4GFWeuYPUVVhvmYwx9N49EsQTonVJihYtcMo1Q==",
       "requires": {
         "robust-compress": "^1.0.0",
         "robust-scale": "^1.0.0",
@@ -5806,16 +5182,16 @@
     "robust-dot-product": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-dot-product/-/robust-dot-product-1.0.0.tgz",
-      "integrity": "sha1-yboBeL0sMEv9cl9Y6Inx2UYARVM=",
+      "integrity": "sha512-Nu/wah8B8RotyZLRPdlEL0ZDh3b7wSwUBLdbTHwS/yw0qqjMJ943PSCkd6EsF5R5QFDWF2x77DGsbmnv9/7/ew==",
       "requires": {
         "robust-sum": "^1.0.0",
         "two-product": "^1.0.0"
       }
     },
     "robust-in-sphere": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.1.3.tgz",
-      "integrity": "sha1-HFiD0WpOkjkpR27zSBmFe/Kpz3U=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/robust-in-sphere/-/robust-in-sphere-1.2.1.tgz",
+      "integrity": "sha512-3zJdcMIOP1gdwux93MKTS0RiMYEGwQBoE5R1IW/9ZQmGeZzP7f7i4+xdcK8ujJvF/dEOS1WPuI9IB1WNFbj3Cg==",
       "requires": {
         "robust-scale": "^1.0.0",
         "robust-subtract": "^1.0.0",
@@ -5826,15 +5202,15 @@
     "robust-linear-solve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-linear-solve/-/robust-linear-solve-1.0.0.tgz",
-      "integrity": "sha1-DNasUEBpGm8qo81jEdcokFyjofE=",
+      "integrity": "sha512-I1qW8Bl9+UYeGNh2Vt8cwkcD74xWMyjnU6lSVcZrf0eyfwPmreflY3v0SvqCZOj5ddxnSS1Xp31igbFNcg1TGQ==",
       "requires": {
         "robust-determinant": "^1.1.0"
       }
     },
     "robust-orientation": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.1.3.tgz",
-      "integrity": "sha1-2v9bANO+TmByLw6cAVbvln8cIEk=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/robust-orientation/-/robust-orientation-1.2.1.tgz",
+      "integrity": "sha512-FuTptgKwY6iNuU15nrIJDLjXzCChWB+T4AvksRtwPS/WZ3HuP1CElCm1t+OBfgQKfWbtZIawip+61k7+buRKAg==",
       "requires": {
         "robust-scale": "^1.0.2",
         "robust-subtract": "^1.0.0",
@@ -5845,7 +5221,7 @@
     "robust-product": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-product/-/robust-product-1.0.0.tgz",
-      "integrity": "sha1-aFJQAHzbunzx3nW/9tKScBEJir4=",
+      "integrity": "sha512-7ww6m+ICW6Dt7ylHVy1aeeNwTfMXfh2BHqHVNE+CHvrU9sI97Vb6uHnid0MN3I9afTI5DXOB7q4SQa2fxuo2Gw==",
       "requires": {
         "robust-scale": "^1.0.0",
         "robust-sum": "^1.0.0"
@@ -5854,7 +5230,7 @@
     "robust-scale": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/robust-scale/-/robust-scale-1.0.2.tgz",
-      "integrity": "sha1-d1Ey7QlULQKOWLLMecBikLz3jDI=",
+      "integrity": "sha512-jBR91a/vomMAzazwpsPTPeuTPPmWBacwA+WYGNKcRGSh6xweuQ2ZbjRZ4v792/bZOhRKXRiQH0F48AvuajY0tQ==",
       "requires": {
         "two-product": "^1.0.2",
         "two-sum": "^1.0.0"
@@ -5863,7 +5239,7 @@
     "robust-segment-intersect": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/robust-segment-intersect/-/robust-segment-intersect-1.0.1.tgz",
-      "integrity": "sha1-MlK2oPwboUreaRXMvgnLzpqrHBw=",
+      "integrity": "sha512-QWngxcL7rCRLK7nTMcTNBPi/q+fecrOo6aOtTPnXjT/Dve5AK20DzUSq2fznUS+rCAxyir6OdPgDCzcUxFtJoQ==",
       "requires": {
         "robust-orientation": "^1.1.3"
       }
@@ -5871,17 +5247,17 @@
     "robust-subtract": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-subtract/-/robust-subtract-1.0.0.tgz",
-      "integrity": "sha1-4LFk4e2LpOOl3aRaEgODSNvtPpo="
+      "integrity": "sha512-xhKUno+Rl+trmxAIVwjQMiVdpF5llxytozXJOdoT4eTIqmqsndQqFb1A0oiW3sZGlhMRhOi6pAD4MF1YYW6o/A=="
     },
     "robust-sum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/robust-sum/-/robust-sum-1.0.0.tgz",
-      "integrity": "sha1-FmRuUlKStNJdgnV6KGlV4Lv6U9k="
+      "integrity": "sha512-AvLExwpaqUqD1uwLU6MwzzfRdaI6VEZsyvQ3IAQ0ZJ08v1H+DTyqskrf2ZJyh0BDduFVLN7H04Zmc+qTiahhAw=="
     },
     "rw": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -5898,14 +5274,9 @@
       }
     },
     "sane-topojson": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-2.0.0.tgz",
-      "integrity": "sha1-QOJXNqKMTM6qojP0W7hjc6J4W4Q="
-    },
-    "seedrandom": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
-      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/sane-topojson/-/sane-topojson-4.0.0.tgz",
+      "integrity": "sha512-bJILrpBboQfabG3BNnHI2hZl52pbt80BE09u4WhnrmzuF2JbMKZdl62G5glXskJ46p+gxE2IzOwGj/awR4g8AA=="
     },
     "semver": {
       "version": "4.3.6",
@@ -5934,35 +5305,7 @@
     "shallow-copy": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
-      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
-    },
-    "sharkdown": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.0.tgz",
-      "integrity": "sha1-YdT+Up510CRCEnzJI0NiJlCZIU8=",
-      "requires": {
-        "cardinal": "~0.4.2",
-        "expect.js": "~0.2.0",
-        "minimist": "0.0.5",
-        "split": "~0.2.10",
-        "stream-spigot": "~2.1.2",
-        "through": "~2.3.4"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.5",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
-          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
-        }
-      }
-    },
-    "shuffle-seed": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/shuffle-seed/-/shuffle-seed-1.1.6.tgz",
-      "integrity": "sha1-UzwSaDurO0+j6HUfxOViFGdEJgs=",
-      "requires": {
-        "seedrandom": "^2.4.2"
-      }
+      "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw=="
     },
     "sigmund": {
       "version": "1.0.1",
@@ -5979,12 +5322,12 @@
     "signum": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-0.0.0.tgz",
-      "integrity": "sha1-q1UbEAM1EHCnBHg/GgnF52kfnPY="
+      "integrity": "sha512-nct2ZUmwemVxeuPY5h+JLpHGJvLCXXNahGVI7IB3a6Fy5baX9AGSb854HceYH4FBw4eGjoZfEo9YRfkGfKdZQA=="
     },
     "simplicial-complex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-1.0.0.tgz",
-      "integrity": "sha1-bDOk7Wn81Nkbe8rdOzC2NoPq4kE=",
+      "integrity": "sha512-mHauIKSOy3GquM5VnYEiu7eP5y4A8BiaN9ezUUgyYFz1k68PqDYcyaH3kenp2cyvWZE96QKE3nrxYw65Allqiw==",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "union-find": "^1.0.0"
@@ -5993,7 +5336,7 @@
     "simplicial-complex-boundary": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simplicial-complex-boundary/-/simplicial-complex-boundary-1.0.1.tgz",
-      "integrity": "sha1-csn/HiTeqjdMm7L6DL8MCB6++BU=",
+      "integrity": "sha512-hz/AaVbs+s08EVoxlbCE68AlC6/mxFJLxJrGRMbDoTjz3030nhcOq+w5+f0/ZaU2EYjmwa8CdVKpiRVIrhaZjA==",
       "requires": {
         "boundary-cells": "^2.0.0",
         "reduce-simplicial-complex": "^1.0.0"
@@ -6002,7 +5345,7 @@
     "simplicial-complex-contour": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/simplicial-complex-contour/-/simplicial-complex-contour-1.0.2.tgz",
-      "integrity": "sha1-iQqsrChDZTQBEFRc8mKaJuBL+dE=",
+      "integrity": "sha512-Janyqvpa7jgr9MJbwR/XGyYz7bdhXNq7zgHxD0G54LCRNyn4bf3Hely2iWQeK/IGu3c5BaWFUh7ElxqXhKrq0g==",
       "requires": {
         "marching-simplex-table": "^1.0.0",
         "ndarray": "^1.0.15",
@@ -6013,7 +5356,7 @@
     "simplify-planar-graph": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/simplify-planar-graph/-/simplify-planar-graph-2.0.1.tgz",
-      "integrity": "sha1-vIWJNyXzLo+oriVoE5hEbSy892Y=",
+      "integrity": "sha512-KdC2ZPFvrGl9+lH/P3Yik7G0si2Zpk6Xiqjq8l9U1lOox5a/9dGLjevi9tvqoh4V7yQbs7fs6+rNCOAdrzUktw==",
       "requires": {
         "robust-orientation": "^1.0.1",
         "simplicial-complex": "^0.3.3"
@@ -6022,12 +5365,12 @@
         "bit-twiddle": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-0.0.2.tgz",
-          "integrity": "sha1-wurruVKjuUrMFASX4c3NLxoz9Y4="
+          "integrity": "sha512-76iFAOrkcuw5UPA30Pt32XaytMHXz/04JembgIwsQAp7ImHYSWNq1shBbrlWf6CUvh1+amQ81LI8hNhqQgsBEw=="
         },
         "simplicial-complex": {
           "version": "0.3.3",
           "resolved": "https://registry.npmjs.org/simplicial-complex/-/simplicial-complex-0.3.3.tgz",
-          "integrity": "sha1-TDDK1X+eRXKd2PMGyHU1efRr6Z4=",
+          "integrity": "sha512-JFSxp7I5yORuKSuwGN96thhkqZVvYB4pkTMkk+PKP2QsOYYU1e84OBoHwOpFyFmjyvB9B3UDZKzHQI5S/CPUPA==",
           "requires": {
             "bit-twiddle": "~0.0.1",
             "union-find": "~0.0.3"
@@ -6036,16 +5379,16 @@
         "union-find": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/union-find/-/union-find-0.0.4.tgz",
-          "integrity": "sha1-uFSzMBYZva0USwAUx4+W6sDS8PY="
+          "integrity": "sha512-207oken6EyGDCBK5l/LTPsWfgy8N8s6idwRK2TG0ssWhzPlxEDdBA8nIV+eLbkEMdA8pAwE8F7/xwv2sCESVjQ=="
         }
       }
     },
     "slab-decomposition": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.2.tgz",
-      "integrity": "sha1-He1WdU1AixBznxRRA9/GGAf2UTQ=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/slab-decomposition/-/slab-decomposition-1.0.3.tgz",
+      "integrity": "sha512-1EfR304JHvX9vYQkUi4AKqN62mLsjk6W45xTk/TxwN8zd3HGwS7PVj9zj0I6fgCZqfGlimDEY+RzzASHn97ZmQ==",
       "requires": {
-        "binary-search-bounds": "^1.0.0",
+        "binary-search-bounds": "^2.0.0",
         "functional-red-black-tree": "^1.0.0",
         "robust-orientation": "^1.1.3"
       }
@@ -6149,25 +5492,6 @@
         "kind-of": "^3.2.0"
       }
     },
-    "sort-asc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
-      "integrity": "sha1-q3md9h/HPqCVbHnEtTHtHp53J+k="
-    },
-    "sort-desc": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
-      "integrity": "sha1-GYuMDN6wlcRjNBhh45JdTuNZqe4="
-    },
-    "sort-object": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
-      "integrity": "sha1-mODRme3kDgfGGoRAPGHWw7KQ+eI=",
-      "requires": {
-        "sort-asc": "^0.1.0",
-        "sort-desc": "^0.1.1"
-      }
-    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6191,11 +5515,6 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
-    },
-    "sourcemap-codec": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz",
-      "integrity": "sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA=="
     },
     "sparkles": {
       "version": "1.0.1",
@@ -6235,18 +5554,10 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
-    "split": {
-      "version": "0.2.10",
-      "resolved": "http://registry.npmjs.org/split/-/split-0.2.10.tgz",
-      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-      "requires": {
-        "through": "2"
-      }
-    },
     "split-polygon": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split-polygon/-/split-polygon-1.0.0.tgz",
-      "integrity": "sha1-DqzIoTanaxKj2VJW6n2kXbDC0kc=",
+      "integrity": "sha512-nBFcgQUVEE8dcOjuKaRdlM53k8RxUYpRxZ//n0pHJQGhbVscrsti+gllJI3pK3y7fgFwGWgt7NFhAX5sz0UoWQ==",
       "requires": {
         "robust-dot-product": "^1.0.0",
         "robust-sum": "^1.0.0"
@@ -6283,21 +5594,21 @@
       }
     },
     "sprintf-js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-      "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+      "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ=="
     },
     "static-eval": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
-      "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.0.tgz",
+      "integrity": "sha512-agtxZ/kWSsCkI5E4QifRwsaPs0P0JmZV6dkLz6ILYfFYQGn+5plctanRN+IC8dJRiFkyXHrwEE3W9Wmx67uDbw==",
       "requires": {
-        "escodegen": "^1.8.1"
+        "escodegen": "^1.11.1"
       }
     },
     "static-extend": {
@@ -6321,118 +5632,6 @@
         }
       }
     },
-    "static-module": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-1.5.0.tgz",
-      "integrity": "sha1-J9qYg8QajNCSNvhC8MHrxu32PYY=",
-      "requires": {
-        "concat-stream": "~1.6.0",
-        "duplexer2": "~0.0.2",
-        "escodegen": "~1.3.2",
-        "falafel": "^2.1.0",
-        "has": "^1.0.0",
-        "object-inspect": "~0.4.0",
-        "quote-stream": "~0.0.0",
-        "readable-stream": "~1.0.27-1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "~0.2.0",
-        "through2": "~0.4.1"
-      },
-      "dependencies": {
-        "escodegen": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
-          "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
-          "requires": {
-            "esprima": "~1.1.1",
-            "estraverse": "~1.5.0",
-            "esutils": "~1.0.0",
-            "source-map": "~0.1.33"
-          }
-        },
-        "esprima": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
-          "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
-        },
-        "estraverse": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
-          "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
-        },
-        "esutils": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
-          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
-        },
-        "object-inspect": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-0.4.0.tgz",
-          "integrity": "sha1-9RV8EWwUVbJDsG7pdwM5LFrYn+w="
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "optional": true,
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        },
-        "static-eval": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-0.2.4.tgz",
-          "integrity": "sha1-t9NNg4k3uWn5ZBygfUj47eJj6ns=",
-          "requires": {
-            "escodegen": "~0.0.24"
-          },
-          "dependencies": {
-            "escodegen": {
-              "version": "0.0.28",
-              "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-0.0.28.tgz",
-              "integrity": "sha1-Dk/xcV8yh3XWyrUaxEpAbNer/9M=",
-              "requires": {
-                "esprima": "~1.0.2",
-                "estraverse": "~1.3.0",
-                "source-map": ">= 0.1.2"
-              }
-            },
-            "esprima": {
-              "version": "1.0.4",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
-              "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
-            },
-            "estraverse": {
-              "version": "1.3.2",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.3.2.tgz",
-              "integrity": "sha1-N8K4k+8T1yPydth41g2FNRUqbEI="
-            }
-          }
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
     "stream-consume": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
@@ -6440,39 +5639,16 @@
       "dev": true
     },
     "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
+    "string-split-by": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
-    "stream-spigot": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/stream-spigot/-/stream-spigot-2.1.2.tgz",
-      "integrity": "sha1-feFF6Bn43Q20UJDRPc9zqO08wDU=",
+      "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
+      "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
       "requires": {
-        "readable-stream": "~1.1.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
-    },
-    "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.0",
-        "function-bind": "^1.0.2"
+        "parenthesis": "^3.1.5"
       }
     },
     "string_decoder": {
@@ -6484,6 +5660,7 @@
       "version": "3.0.1",
       "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -6498,11 +5675,6 @@
         "is-utf8": "^0.2.0"
       }
     },
-    "strip-bom-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-      "integrity": "sha1-5SEekiQ2n7uB1jOi8ABE3IztrZI="
-    },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -6515,33 +5687,25 @@
     "strongly-connected-components": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
-      "integrity": "sha1-CSDitN9nyOrulsa2I0/inoc9upk="
+      "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA=="
     },
     "supercluster": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-2.3.0.tgz",
-      "integrity": "sha1-h6tWCBu+qaHXJN9TUe6ejDry9Is=",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
       "requires": {
-        "kdbush": "^1.0.1"
+        "kdbush": "^3.0.0"
       }
     },
     "superscript-text": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
-      "integrity": "sha1-58snUlZzYN9QvrBhDOjfPXHY39g="
-    },
-    "supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
+      "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ=="
     },
     "surface-nets": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/surface-nets/-/surface-nets-1.0.2.tgz",
-      "integrity": "sha1-5DPIy7qUpydMb0yZVStGG/H8eks=",
+      "integrity": "sha512-Se+BaCb5yc8AV1IfT6TwTWEe/KuzzjzcMQQCbcIahzk9xRO5bIxxGM2MmKxE9nmq8+RD8DLBLXu0BjXoRs21iw==",
       "requires": {
         "ndarray-extract-contour": "^1.0.0",
         "triangulate-hypercube": "^1.0.0",
@@ -6549,14 +5713,14 @@
       }
     },
     "svg-arc-to-cubic-bezier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.1.2.tgz",
-      "integrity": "sha512-scEWWUoCDhBtgamRnW8C4b0Va73GdpxwWs01SH/wNsl+al7FHEHsval/ZnutHfzvrNTcn/A3YIsQ1oNULSFS7g=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g=="
     },
     "svg-path-bounds": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.1.tgz",
-      "integrity": "sha1-v0WLeDcmv1NDG0Yz8nkvYHSNn3Q=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
+      "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
       "requires": {
         "abs-svg-path": "^0.1.1",
         "is-svg-path": "^1.0.1",
@@ -6565,9 +5729,9 @@
       },
       "dependencies": {
         "normalize-svg-path": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.0.1.tgz",
-          "integrity": "sha1-b3Ka1rcLtMpO/y/ksQdInv4dVv4=",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+          "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
           "requires": {
             "svg-arc-to-cubic-bezier": "^3.0.0"
           }
@@ -6575,35 +5739,15 @@
       }
     },
     "svg-path-sdf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.2.tgz",
-      "integrity": "sha512-dOH+KAAQMPh3phURH1gg4PjulxyuEzGESMjHiy4l4vGCrXpzGemH19e4VUTAXs6ipEUoHsVNdaG0i0CMMdFNVQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
+      "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
       "requires": {
         "bitmap-sdf": "^1.0.0",
         "draw-svg-path": "^1.0.0",
         "is-svg-path": "^1.0.1",
         "parse-svg-path": "^0.1.2",
         "svg-path-bounds": "^1.0.1"
-      }
-    },
-    "tape": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
-      "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
-      "requires": {
-        "deep-equal": "~1.0.1",
-        "defined": "~1.0.0",
-        "for-each": "~0.3.3",
-        "function-bind": "~1.1.1",
-        "glob": "~7.1.2",
-        "has": "~1.0.3",
-        "inherits": "~2.0.3",
-        "minimist": "~1.2.0",
-        "object-inspect": "~1.6.0",
-        "resolve": "~1.7.1",
-        "resumer": "~0.0.0",
-        "string.prototype.trim": "~1.1.2",
-        "through": "~2.3.8"
       }
     },
     "temp-write": {
@@ -6634,17 +5778,12 @@
       }
     },
     "text-cache": {
-      "version": "4.1.0",
-      "resolved": "http://registry.npmjs.org/text-cache/-/text-cache-4.1.0.tgz",
-      "integrity": "sha1-fFgJDoWsCRD5dt9M/Izoqg6lh2Y=",
+      "version": "4.2.2",
+      "resolved": "http://registry.npmjs.org/text-cache/-/text-cache-4.2.2.tgz",
+      "integrity": "sha512-zky+UDYiX0a/aPw/YTBD+EzKMlCTu1chFuCMZeAkgoRiceySdROu1V2kJXhCbtEdBhiOviYnAdGiSYl58HW0ZQ==",
       "requires": {
-        "vectorize-text": "^3.0.1"
+        "vectorize-text": "^3.2.1"
       }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "0.6.5",
@@ -6670,25 +5809,20 @@
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
-    "tiny-sdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tiny-sdf/-/tiny-sdf-1.0.2.tgz",
-      "integrity": "sha1-KOdphcRMTlhMS2fY7N2bM6HKwow="
-    },
     "tinycolor2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
-      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
     },
     "tinyqueue": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
-      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "to-float32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.0.0.tgz",
-      "integrity": "sha512-AtYAqiHS1q+IqVfZOExaRC72mUZuMZP7yU1xsR07y0SLLEvPf68R+xGfya3eY4CR7jxT/zQt3wM8w4mGq/mPXA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
+      "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg=="
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -6702,7 +5836,7 @@
     "to-px": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
-      "integrity": "sha1-W7rtXl1PdkRbzJA8KTojB90yRkY=",
+      "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
       "requires": {
         "parse-unit": "^1.0.1"
       }
@@ -6751,9 +5885,9 @@
       }
     },
     "topojson-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-2.1.0.tgz",
-      "integrity": "sha1-/59784mRGF4LQoTCsGroNPDqxsg=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "requires": {
         "commander": "2"
       }
@@ -6761,7 +5895,7 @@
     "triangulate-hypercube": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/triangulate-hypercube/-/triangulate-hypercube-1.0.1.tgz",
-      "integrity": "sha1-2Acdsuv8/VHzCNC88qXEils20Tc=",
+      "integrity": "sha512-SAIacSBfUNfgeCna8q2i+1taOtFJkYuOqpduaJ1KUeOJpqc0lLKMYzPnZb4CA6KCOiD8Pd4YbuVq41wa9dvWyw==",
       "requires": {
         "gamma": "^0.1.0",
         "permutation-parity": "^1.0.0",
@@ -6771,7 +5905,7 @@
     "triangulate-polyline": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/triangulate-polyline/-/triangulate-polyline-1.0.3.tgz",
-      "integrity": "sha1-v4uod6hQVBA/65+lphtOjXAXgU0=",
+      "integrity": "sha512-crJcVFtVPFYQ8r9iIhe9JqkauDvNWDSZLot8ly3DniSCO+zyUfKbtfD3fEoBaA5uMrQU/zBi11NBuVQeSToToQ==",
       "requires": {
         "cdt2d": "^1.0.0"
       }
@@ -6785,7 +5919,7 @@
     "turntable-camera-controller": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/turntable-camera-controller/-/turntable-camera-controller-3.0.1.tgz",
-      "integrity": "sha1-jb0/4AVQGRxlFky4iJcQSVeK/Zk=",
+      "integrity": "sha512-UOGu9W/Mx053pAaczi0BEPqvWJOqSgtpdigWG9C8dX8rQVdyl2hWmpdJW3m15QrGxJtJHIhhDTHVtTZzPkd/FA==",
       "requires": {
         "filtered-vector": "^1.2.1",
         "gl-mat4": "^1.0.2",
@@ -6795,17 +5929,22 @@
     "two-product": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/two-product/-/two-product-1.0.2.tgz",
-      "integrity": "sha1-Z9ldSyV6kh4stL16+VEfkIhSLqo="
+      "integrity": "sha512-vOyrqmeYvzjToVM08iU52OFocWT6eB/I5LUWYnxeAPGXAhAxXYU/Yr/R2uY5/5n4bvJQL9AQulIuxpIsMoT8XQ=="
     },
     "two-sum": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/two-sum/-/two-sum-1.0.0.tgz",
-      "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
+      "integrity": "sha512-phP48e8AawgsNUjEY2WvoIWqdie8PoiDZGxTDv70LDr01uX5wLEQbOgSP7Z/B6+SW5oLtbe8qaYX2fKJs3CGTw=="
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
     },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -6821,32 +5960,15 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typedarray-pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.1.0.tgz",
-      "integrity": "sha1-0RT0hIAUifU+yrXoCIqiMET0mNk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
       "requires": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
-      }
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
       }
     },
     "uglify-save-license": {
@@ -6858,41 +5980,8 @@
     "uglify-to-browserify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
-    },
-    "unassert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/unassert/-/unassert-1.5.1.tgz",
-      "integrity": "sha1-y8iOw4dBfFpeTALTzQe+mL11/3Y=",
-      "requires": {
-        "acorn": "^4.0.0",
-        "call-matcher": "^1.0.1",
-        "deep-equal": "^1.0.0",
-        "espurify": "^1.3.0",
-        "estraverse": "^4.1.0",
-        "esutils": "^2.0.2",
-        "object-assign": "^4.1.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
-        }
-      }
-    },
-    "unassertify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/unassertify/-/unassertify-2.1.1.tgz",
-      "integrity": "sha512-YIAaIlc6/KC9Oib8cVZLlpDDhK1UTEuaDyx9BwD97xqxDZC0cJOqwFcs/Y6K3m73B5VzHsRTBLXNO0dxS/GkTw==",
-      "requires": {
-        "acorn": "^5.1.0",
-        "convert-source-map": "^1.1.1",
-        "escodegen": "^1.6.1",
-        "multi-stage-sourcemap": "^0.2.1",
-        "through": "^2.3.7",
-        "unassert": "^1.3.1"
-      }
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -6900,48 +5989,10 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
     },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
-    },
-    "unflowify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unflowify/-/unflowify-1.0.1.tgz",
-      "integrity": "sha1-ouoNJcCv/MRpVeZHNXX3xaH0ppY=",
-      "requires": {
-        "flow-remove-types": "^1.1.2",
-        "through": "^2.3.8"
-      }
-    },
-    "unicode-canonical-property-names-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ=="
-    },
-    "unicode-match-property-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
-      "requires": {
-        "unicode-canonical-property-names-ecmascript": "^1.0.4",
-        "unicode-property-aliases-ecmascript": "^1.0.4"
-      }
-    },
-    "unicode-match-property-value-ecmascript": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
-    },
-    "unicode-property-aliases-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
-    },
     "union-find": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/union-find/-/union-find-1.0.2.tgz",
-      "integrity": "sha1-KSusQV5q06iVNdI3AQ20pTYoTlg="
+      "integrity": "sha512-wFA9bMD/40k7ZcpKVXfu6X1qD3ri5ryO8HUsuA1RnxPCQl66Mu6DgkxyR+XNnd+osD0aLENixcJVFj+uf+O4gw=="
     },
     "union-value": {
       "version": "1.0.0",
@@ -6972,13 +6023,18 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA=="
     },
     "unique-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
       "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs=",
       "dev": true
+    },
+    "unquote": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -7029,7 +6085,7 @@
     "update-diff": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
-      "integrity": "sha1-9RAYLYHugZ+4LDprIrYrve2ngI8="
+      "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A=="
     },
     "urix": {
       "version": "0.1.0",
@@ -7080,14 +6136,14 @@
       }
     },
     "vectorize-text": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.0.2.tgz",
-      "integrity": "sha1-BasWMOQJ83eWTiuSBbLVWakvYNg=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/vectorize-text/-/vectorize-text-3.2.2.tgz",
+      "integrity": "sha512-34NVOCpMMQVXujU4vb/c6u98h6djI0jGdtC202H4Huvzn48B6ARsR7cmGh1xsAc0pHNQiUKGK/aHF05VtGv+eA==",
       "requires": {
         "cdt2d": "^1.0.0",
         "clean-pslg": "^1.1.0",
         "ndarray": "^1.0.11",
-        "planar-graph-to-polyline": "^1.0.0",
+        "planar-graph-to-polyline": "^1.0.6",
         "simplify-planar-graph": "^2.0.1",
         "surface-nets": "^1.0.0",
         "triangulate-polyline": "^1.0.0"
@@ -7164,48 +6220,33 @@
         }
       }
     },
-    "vlq": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
-      "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g=="
-    },
     "vt-pbf": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
-      "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
+      "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
       "requires": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
-        "pbf": "^3.0.5"
+        "pbf": "^3.2.1"
       }
     },
     "weak-map": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz",
-      "integrity": "sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
+      "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw=="
     },
     "weakmap-shim": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
-      "integrity": "sha1-1lr9eEEJshZuAP9XHDMVDsKkC0k="
+      "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
     },
     "webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
-      "integrity": "sha1-jzfXJXz23xzQpJ5qextyG5TMhqA=",
+      "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
       "requires": {
         "get-canvas-context": "^1.0.1"
       }
-    },
-    "webworkify": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/webworkify/-/webworkify-1.5.0.tgz",
-      "integrity": "sha512-AMcUeyXAhbACL8S2hqqdqOLqvJ8ylmIbNwUIqQujRSouf4+eUFaXbG6F1Rbu+srlJMmxQWsiU7mOJi0nMBfM1g=="
-    },
-    "wgs84": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
-      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "which": {
       "version": "1.3.1",
@@ -7219,17 +6260,18 @@
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "world-calendars": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.3.tgz",
-      "integrity": "sha1-slxQMrokEo/8QdCfr0pewbnBQzU=",
+      "integrity": "sha512-sAjLZkBnsbHkHWVhrsCU5Sa/EVuf9QqgvrN8zyJ2L/F9FR9Oc6CvVK0674+PGAtmmmYQMH98tCUSO4QLQv3/TQ==",
       "requires": {
         "object-assign": "^4.1.0"
       }
@@ -7248,6 +6290,7 @@
       "version": "3.10.0",
       "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
       "requires": {
         "camelcase": "^1.0.2",
         "cliui": "^2.1.0",
@@ -7258,7 +6301,7 @@
     "zero-crossings": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/zero-crossings/-/zero-crossings-1.0.1.tgz",
-      "integrity": "sha1-xWK9MRNkPzRDokXRJAa4i2m5qf8=",
+      "integrity": "sha512-iNIldMZaDtAyIJMJ8NnGVHeejH//y4eVmpXriM+q/B/BPNz+2E7oAgSnw9MXqCd3RbQ8W+hor7T2jEyRoc/s2A==",
       "requires": {
         "cwise-compiler": "^1.0.0"
       }

--- a/samples/csharp/end-to-end-apps/Forecasting-Sales/src/eShopDashboard/package.json
+++ b/samples/csharp/end-to-end-apps/Forecasting-Sales/src/eShopDashboard/package.json
@@ -6,7 +6,7 @@
     "bootstrap": "4.3.1",
     "jquery": "3.4.0",
     "lodash": "4.17.13",
-    "plotly.js": "1.36.1",
+    "plotly.js": "1.58.5",
     "popper.js": "1.14.3",
     "typeahead.js": "0.11.1"
   },


### PR DESCRIPTION
Bumps [minimist](https://github.com/minimistjs/minimist) to 1.2.8 and updates ancestor dependencies [minimist](https://github.com/minimistjs/minimist), [plotly.js](https://github.com/plotly/plotly.js) and [mkdirp](https://github.com/isaacs/node-mkdirp). These dependencies need to be updated together.


Updates `minimist` from 1.2.0 to 1.2.8
- [Changelog](https://github.com/minimistjs/minimist/blob/main/CHANGELOG.md)
- [Commits](https://github.com/minimistjs/minimist/compare/v1.2.0...v1.2.8)

Updates `minimist` from 0.2.0 to 1.2.8
- [Changelog](https://github.com/minimistjs/minimist/blob/main/CHANGELOG.md)
- [Commits](https://github.com/minimistjs/minimist/compare/v1.2.0...v1.2.8)

Updates `plotly.js` from 1.36.1 to 1.58.5
- [Release notes](https://github.com/plotly/plotly.js/releases)
- [Changelog](https://github.com/plotly/plotly.js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/plotly/plotly.js/compare/v1.36.1...v1.58.5)

Updates `mkdirp` from 0.5.1 to 0.5.6
- [Changelog](https://github.com/isaacs/node-mkdirp/blob/main/CHANGELOG.md)
- [Commits](https://github.com/isaacs/node-mkdirp/compare/0.5.1...v0.5.6)

---
updated-dependencies:
- dependency-name: minimist dependency-type: indirect
- dependency-name: minimist dependency-type: indirect
- dependency-name: plotly.js dependency-type: direct:production
- dependency-name: mkdirp dependency-type: indirect ...